### PR TITLE
Added default sort order to config and nodes view

### DIFF
--- a/src/app/config/config.controller.ts
+++ b/src/app/config/config.controller.ts
@@ -172,6 +172,7 @@ export class ConfigController {
         })
         .withBootstrap()
         .withPaginationType('simple_numbers')
+        .withOption('order', [[2, 'asc'], [1, 'asc']])
         .withOption('aaSorting', [])
         .withOption('aaSortingFixed', [])
         .withOption('paging', false)

--- a/src/app/nodes/nodes.controller.ts
+++ b/src/app/nodes/nodes.controller.ts
@@ -89,6 +89,7 @@ export class NodesController {
         })
         .withBootstrap()
         .withPaginationType('simple_numbers')
+        .withOption('order', [[2, 'asc'], [1, 'asc']])
         .withOption('aaSorting', [])
         .withOption('stateSave', true)
         .withOption('aaSortingFixed', [])


### PR DESCRIPTION
Add default sort order (POSITION, NAME) to NODES and CONFIG tables.
Otherwise it's a mess.