### PR TITLE
Improved handling of cancelled API calls and fixed perception

### DIFF
--- a/src/app/config/config.controller.ts
+++ b/src/app/config/config.controller.ts
@@ -318,6 +318,10 @@ export class ConfigController {
 
             return result;
         }, (error: any) => {
+            if (error.cancelled) {
+                return;
+            }
+
             this.toastr.error('ERROR RELOADING CONFIG: ' + error.statusText);
 
             this.configInfo = undefined;

--- a/src/app/dashboard/dashboard.controller.ts
+++ b/src/app/dashboard/dashboard.controller.ts
@@ -335,7 +335,7 @@ export class DashboardController {
             },
             function(error: any) {
                 if (!error.cancelled) {
-                    vm.toastr.error('ERROR RETRIEVING MINERS METRICS: ' + error.status);
+                    vm.toastr.error('ERROR RETRIEVING MINERS METRICS: ' + error.statusText);
                 }
 
                 throw error;
@@ -425,7 +425,7 @@ export class DashboardController {
             },
             function(error: any) {
                 if (!error.cancelled) {
-                    vm.toastr.error('ERROR RETRIEVING OUTPUTS METRICS: ' + error.status);
+                    vm.toastr.error('ERROR RETRIEVING OUTPUTS METRICS: ' + error.statusText);
                 }
 
                 throw error;
@@ -483,7 +483,7 @@ export class DashboardController {
             },
             function(error: any) {
                 if (!error.cancelled) {
-                    vm.toastr.error('ERROR RETRIEVING MINEMELD METRICS: ' + error.status);
+                    vm.toastr.error('ERROR RETRIEVING MINEMELD METRICS: ' + error.statusText);
                 }
 
                 throw error;

--- a/src/app/dashboard/system.controller.ts
+++ b/src/app/dashboard/system.controller.ts
@@ -59,7 +59,9 @@ export class SystemController {
                 vm.system = result;
             },
             function(error: any) {
-                vm.toastr.error('ERROR RETRIEVING SYSTEM STATUS: ' + error.status);
+                if (!error.cancelled) {
+                    vm.toastr.error('ERROR RETRIEVING SYSTEM STATUS: ' + error.statusText);
+                }
             }
         )
         .finally(function() {
@@ -88,7 +90,9 @@ export class SystemController {
                 }
             },
             function(error: any) {
-                vm.toastr.error('ERROR RETRIEVING SUPERVISOR STATUS: ' + error.status);
+                if (!error.cancelled) {
+                    vm.toastr.error('ERROR RETRIEVING SUPERVISOR STATUS: ' + error.statusText);
+                }
             }
         )
         .finally(function() {

--- a/src/app/index.init.ts
+++ b/src/app/index.init.ts
@@ -17,6 +17,14 @@ export function minemeldInit($state: angular.ui.IStateService,
         return;
     };
 
+    $rootScope.$on('$stateChangeStart', (event: any, toState: any, toParams: any) => {
+        if (toState.name !== 'login' && !MineMeldAPIService.isLoggedIn()) {
+            event.preventDefault();
+            $state.go('login');
+        }
+    });
+
+
     $rootScope.$on('$stateChangeSuccess', (event: any, toState: any, toParams: any, fromState: any, fromParams: any) => {
         $rootScope.mmPreviousState = {
             state: fromState,

--- a/src/app/services/events.ts
+++ b/src/app/services/events.ts
@@ -110,6 +110,13 @@ export class MinemeldEventsService implements IMinemeldEventsService {
     }
 
     private onError(subtype: string, event: string, e: any) {
+        if (typeof e.data !== 'undefined') {
+            if (e.data.indexOf('401') !== -1) {
+                this.$state.go('login');
+                return;
+            }
+        }
+
         angular.forEach(this.subscriptions, (sub: ISubscription) => {
            if ((sub.subType !== subtype) || (sub.topic !== event)) {
                return;

--- a/src/app/services/traced.ts
+++ b/src/app/services/traced.ts
@@ -119,7 +119,7 @@ export class MinemeldTracedService implements IMinemeldTracedService {
             get: {
                 method: 'GET'
             }
-        });
+        }, false);
 
         return qResource.get().$promise;
     }


### PR DESCRIPTION
- improved handling in some modules for cancelled API calls (avoid annoying errors showing up)
- added cancellable=false to kill query API call
- added loggedIn attribute in MineMeld API service to automatically redirect non authenticated users to login. This is not for security, just to fix perceptions.

Signed-off-by: Luigi Mori <l@isidora.org>