### PR TITLE
Simplified conifguration view

### DIFF
--- a/bower-shrinkwrap.json
+++ b/bower-shrinkwrap.json
@@ -2,8 +2,8 @@
   "https://github.com/Caged/d3-tip.git": {
     "0.6.7": "0.6.7"
   },
-  "https://github.com/DataTables/DataTables.git": {
-    "1.10.12": "b31abf704462a45f6ba7db439862d23c8cedc1f4"
+  "https://github.com/DataTables/Dist-DataTables.git": {
+    "1.10.12": "1.10.12"
   },
   "https://github.com/Foxandxss/angular-toastr.git": {
     "1.5.0": "1.5.0"
@@ -60,19 +60,19 @@
     "3.4.0": "3.4.0"
   },
   "https://github.com/jquery/jquery-dist.git": {
-    "2.1.4": "2.1.4"
+    "2.1.4": "2.1.4",
+    "3.0.0": "0078f86be166a8747819d5d1516776a662cb69df"
   },
   "https://github.com/krispo/angular-nvd3.git": {
     "1.0.6": "1.0.6"
   },
   "https://github.com/l-lin/angular-datatables.git": {
-    "0.5.4": "0.5.4"
+    "0.5.5": "0.5.5"
   },
   "https://github.com/mathiasbynens/he.git": {
     "0.5.0": "0.5.0"
   },
   "https://github.com/mbostock-bower/d3-bower.git": {
-    "3.5.17": "abe0262a205c9f3755c3a757de4dfd1d49f34b24",
     "3.5.5": "3.5.5"
   },
   "https://github.com/moment/moment.git": {
@@ -88,4 +88,3 @@
     "3.3.6": "3.3.6"
   }
 }
-

--- a/bower-shrinkwrap.json
+++ b/bower-shrinkwrap.json
@@ -60,8 +60,7 @@
     "3.4.0": "3.4.0"
   },
   "https://github.com/jquery/jquery-dist.git": {
-    "2.1.4": "2.1.4",
-    "3.0.0": "0078f86be166a8747819d5d1516776a662cb69df"
+    "2.1.4": "2.1.4"
   },
   "https://github.com/krispo/angular-nvd3.git": {
     "1.0.6": "1.0.6"
@@ -73,7 +72,8 @@
     "0.5.0": "0.5.0"
   },
   "https://github.com/mbostock-bower/d3-bower.git": {
-    "3.5.5": "3.5.5"
+    "3.5.5": "3.5.5",
+    "3.5.17": "abe0262a205c9f3755c3a757de4dfd1d49f34b24"
   },
   "https://github.com/moment/moment.git": {
     "2.10.6": "2.10.6"

--- a/src/app/config/config.scss
+++ b/src/app/config/config.scss
@@ -50,13 +50,19 @@
     background-color: darken($body-bg, 10%) !important;
 }
 
+.config-table-disabled {
+    cursor: default !important;
+    background-image: url("data:image/svg+xml;base64,PHN2ZyB4bWxucz0naHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmcnIHdpZHRoPSc1JyBoZWlnaHQ9JzUnPgogIDxyZWN0IHdpZHRoPSc1JyBoZWlnaHQ9JzUnIGZpbGw9J3doaXRlJyBmaWxsLW9wYWNpdHk9IjAuMCIvPgogIDxwYXRoIGQ9J00wIDVMNSAwWk02IDRMNCA2Wk0tMSAxTDEgLTFaJyBzdHJva2U9JyNkZGQnIHN0cm9rZS13aWR0aD0nMScvPgo8L3N2Zz4K");
+    background-repeat: repeat;
+}
+
 .config-inputs-table > tbody {
     border-top: 2px solid $table-border-color;
     border-bottom: 1px solid $table-border-color;
 }
 
 .config-inputs-table > tbody > tr:hover {
-    background-color: darken($body-bg, 5%);    
+    background-color: darken($body-bg, 5%);
 }
 
 .config-add-form label {

--- a/src/app/config/configadd.view.html
+++ b/src/app/config/configadd.view.html
@@ -43,15 +43,20 @@
         <div class="form-group">
             <label class="col-sm-2 col-md-2 control-label">INPUTS</label>
             <div class="col-sm-6 col-md-6">
-                <ui-select multiple ng-model="vm.inputs" theme="bootstrap">
-                    <ui-select-match placeholder="Select inputs...">{{$item}}</ui-select-match>
-                    <ui-select-choices repeat="input in vm.availableInputs | filter:$select.search">
-                        {{input}}
+                <ui-select multiple ng-model="vm.inputs" theme="bootstrap"
+                           ng-disabled="vm.inputsDisabled"
+                           on-select="vm.inputsChanged()" on-remove="vm.inputsChanged()">
+                    <ui-select-match placeholder="Select input nodes...">{{$item.name}}</ui-select-match>
+                    <ui-select-choices group-by="'nodeType'" repeat="input.name as input in vm.availableInputs | filter: {'name':$select.search}">
+                        <div>
+                            <span ng-bind-html="input.name | highlight: $select.search"></span>
+                        </div>
                     </ui-select-choices>
+                    <ui-select-no-choice><i>{{ vm.noInputsChoiceMessage }}</i></ui-select-no-choice>
                 </ui-select>
             </div>
         </div>
-        <div class="form-group">
+        <div ng-if="false" class="form-group">
             <label class="col-sm-2 col-md-2 control-label">OUTPUT</label>
             <div class="col-sm-6 col-md-6">
                 <span ng-if="!vm.output" class="btn config-btn-disabled btn-sm" type="button" ng-click="vm.output = true">DISABLED</span>

--- a/src/app/config/configexport.controller.ts
+++ b/src/app/config/configexport.controller.ts
@@ -1,0 +1,63 @@
+/// <reference path="../../../typings/main.d.ts" />
+
+import { IMinemeldConfigService, IMinemeldConfigNode } from  '../../app/services/config';
+
+declare var jsyaml: any;
+
+export class ConfigureExportController {
+    $modalInstance: angular.ui.bootstrap.IModalServiceInstance;
+    MinemeldConfigService: IMinemeldConfigService;
+
+    config: string;
+    editor: any;
+
+    /** @ngInject */
+    constructor($modalInstance: angular.ui.bootstrap.IModalServiceInstance,
+                MinemeldConfigService: IMinemeldConfigService) {
+        var vm: any = this;
+
+        this.$modalInstance = $modalInstance;
+        this.MinemeldConfigService = MinemeldConfigService;
+
+        this.dumpYaml();
+
+        /* this is a trick, basically these callbacks are called by ui-ace
+           with this set to Window. To recover *this* instance we define
+           the methods in a scope with *this* captured by a local variable vm */
+        vm.editorLoaded = (editor_: any) => {
+            vm.editor = editor_;
+
+            editor_.setShowInvisibles(false);
+
+            angular.element('.ace_text-input').on('focus', (event: any) => {
+                angular.element(event.currentTarget.parentNode).addClass('ace-focus');
+            });
+            angular.element('.ace_text-input').on('blur', (event: any) => {
+                angular.element(event.currentTarget.parentNode).removeClass('ace-focus');
+            });
+        };
+    }
+
+    copyToClipboard(): void {
+        this.editor.selectAll();
+        this.editor.focus();
+        document.execCommand('copy');
+    }
+
+    ok(): void {
+        this.$modalInstance.dismiss();
+    }
+
+    private dumpYaml(): void {
+        var oconfig: any = {};
+
+        this.MinemeldConfigService.nodesConfig.forEach((currentNode: IMinemeldConfigNode) => {
+            if (currentNode.deleted) {
+                return;
+            }
+            oconfig[currentNode.name] = currentNode.properties;
+        });
+
+        this.config = jsyaml.safeDump(oconfig);
+    }
+}

--- a/src/app/config/configimport.controller.ts
+++ b/src/app/config/configimport.controller.ts
@@ -1,0 +1,400 @@
+/// <reference path="../../../typings/main.d.ts" />
+
+import { IMinemeldConfigService, IMinemeldConfigNode } from  '../../app/services/config';
+import { IMinemeldPrototypeService, IMinemeldPrototypeLibrary } from '../../app/services/prototype';
+import { IConfirmService } from '../../app/services/confirm';
+
+declare var jsyaml: any;
+
+class ConfigAnnotations {
+    private _annotations: { [key: number]: string[] } = {};
+
+    constructor() {
+        /* empty */
+    }
+
+    addAnnotation(row: number, annotation: string): void {
+        if (!(row in this._annotations)) {
+            this._annotations[row] = [];
+        }
+        this._annotations[row].push(annotation);
+    }
+
+    getAnnotations(): any[] {
+        var result: any[] = [];
+        var vm: ConfigAnnotations = this;
+
+        Object.keys(this._annotations).forEach((row: string) => {
+            result.push({
+                row: +row,
+                column: 0,
+                type: 'error',
+                text: vm._annotations[row].join('\n')
+            });
+        });
+
+        return result;
+    }
+
+    length(): number {
+        return Object.keys(this._annotations).length;
+    }
+
+    firstRowNumber(): number {
+        var rows: number[];
+
+        rows = Object.keys(this._annotations).map((v: string): number => { return +v; });
+        if (rows.length !== 0) {
+            return Math.min.apply(null, rows) + 1;
+        }
+
+        return 0;
+    }
+}
+
+export class ConfigureImportController {
+    $modalInstance: angular.ui.bootstrap.IModalServiceInstance;
+    MinemeldConfigService: IMinemeldConfigService;
+    toastr: any;
+    $q: angular.IQService;
+    ConfirmService: IConfirmService;
+    MinemeldPrototypeService: IMinemeldPrototypeService;
+
+    prototypeLibrary: IMinemeldPrototypeLibrary;
+
+    config: string;
+    pconfig: any;
+
+    editor: any;
+    valid: boolean = false;
+    syntaxValid: boolean = false;
+    processing: boolean = true;
+    numAnnotations: number = 0;
+    firstAnnotation: number = 0;
+
+    /** @ngInject */
+    constructor($scope: angular.IScope,
+                $modalInstance: angular.ui.bootstrap.IModalServiceInstance,
+                MinemeldConfigService: IMinemeldConfigService,
+                MinemeldPrototypeService: IMinemeldPrototypeService,
+                toastr: any,
+                $q: angular.IQService,
+                ConfirmService: IConfirmService) {
+        var vm: any = this;
+
+        this.$modalInstance = $modalInstance;
+        this.MinemeldConfigService = MinemeldConfigService;
+        this.MinemeldPrototypeService = MinemeldPrototypeService;
+        this.toastr = toastr;
+        this.$q = $q;
+        this.ConfirmService = ConfirmService;
+
+        MinemeldPrototypeService.getPrototypeLibraries().then((result: any) => {
+            this.prototypeLibrary = result;
+            this.processing = false;
+        }, (error: any) => {
+            this.toastr.error('ERROR RETRIEVING PROTOTYPES: ' + error.statusText);
+            this.$modalInstance.dismiss();
+        });
+
+        /* this is a trick, basically these callbacks are called by ui-ace
+           with this set to Window. To recover *this* instance we define
+           the methods in a scope with *this* captured by a local variable vm */
+        vm.editorLoaded = (editor_: any) => {
+            vm.editor = editor_;
+
+            editor_.setShowInvisibles(false);
+
+            angular.element('.ace_text-input').on('focus', (event: any) => {
+                angular.element(event.currentTarget.parentNode).addClass('ace-focus');
+            });
+            angular.element('.ace_text-input').on('blur', (event: any) => {
+                angular.element(event.currentTarget.parentNode).removeClass('ace-focus');
+            });
+
+            editor_.getSession().setOption('useWorker', false);
+
+            vm.validYaml();
+        };
+        vm.aceChanged = vm.validYaml.bind(this);
+    }
+
+    validYaml(): boolean {
+        var nodeNames: string[];
+        var annotations: ConfigAnnotations = new ConfigAnnotations();
+        var namere = /^[a-zA-Z0-9_\-]+$/;
+
+        if (!this.editor) {
+            return;
+        }
+
+        this.valid = false;
+
+        try {
+            this.pconfig = jsyaml.safeLoad(this.config);
+        } catch (err) {
+            this.syntaxValid = false;
+            return false;
+        }
+        this.syntaxValid = true;
+
+        this.editor.getSession().clearAnnotations();
+        this.numAnnotations = 0;
+
+        if (!this.pconfig || !this.config || this.config.length === 0) {
+            return false;
+        }
+
+        if (typeof this.pconfig.nodes === 'undefined' || typeof this.pconfig.nodes !== 'object') {
+            this.editor.getSession().setAnnotations([{
+                row: 0,
+                column: 0,
+                text: 'Nodes list not defined',
+                type: 'error' // also warning and information
+            }]);
+
+            return false;
+        }
+
+        if (!this.pconfig.nodes) {
+            this.editor.getSession().setAnnotations([{
+                row: 0,
+                column: 0,
+                text: 'Invalid nodes list',
+                type: 'error' // also warning and information
+            }]);
+
+            return false;
+        }
+
+        nodeNames = Object.keys(this.pconfig.nodes);
+        if (nodeNames.length === 0) {
+            this.editor.getSession().setAnnotations([{
+                row: 0,
+                column: 0,
+                text: 'Invalid nodes list',
+                type: 'error' // also warning and information
+            }]);
+
+            return false;
+        }
+
+        angular.forEach(nodeNames, (nodeName: string) => {
+            var node: any;
+            var nodeRow: number;
+            var toks: string[];
+
+            node = this.pconfig.nodes[nodeName];
+
+            if (!namere.test(nodeName)) {
+                annotations.addAnnotation(0, nodeName + ': invalid node name');
+
+                return;
+            }
+
+            if (typeof node !== 'object' || node === null) {
+                annotations.addAnnotation(0, nodeName + ': invalid node format');
+
+                return;
+            }
+
+            nodeRow = this.findNode(nodeName);
+
+            if (typeof node.inputs !== 'undefined') {
+                if (!(node.inputs instanceof Array)) {
+                    annotations.addAnnotation(
+                        nodeRow,
+                        nodeName +  ': wrong inputs list'
+                    );
+                } else {
+                    node.inputs.forEach((i: any) => {
+                        if (typeof i !== 'string') {
+                            annotations.addAnnotation(
+                                nodeRow,
+                                nodeName + ': invalid input ' + i
+                            );
+                        }
+                    });
+                }
+            }
+            if (typeof node.output !== 'boolean') {
+                annotations.addAnnotation(
+                    nodeRow,
+                    nodeName +  ': wrong or missing output field'
+                );
+            }
+            if (typeof node.class !== 'undefined' && typeof node.class !== 'string') {
+                annotations.addAnnotation(
+                    nodeRow,
+                    nodeName +  ': class field if defined should be a string'
+                );
+            }
+            if (typeof node.config !== 'undefined') {
+                if (typeof node.config !== 'object' || !node.config) {
+                    annotations.addAnnotation(
+                        nodeRow,
+                        nodeName +  ': config field if defined should be a dictionary'
+                    );
+                }
+            }
+            if (typeof node.prototype !== 'undefined') {
+                if (typeof node.prototype !== 'string') {
+                    annotations.addAnnotation(
+                        nodeRow,
+                        nodeName +  ': prototype field if defined should be a string'
+                    );
+                } else {
+                    toks = node.prototype.split('.');
+                    if (!(toks[0] in this.prototypeLibrary)) {
+                        annotations.addAnnotation(
+                            nodeRow,
+                            nodeName +  ': unknown prototype library'
+                        );
+                    } else {
+                        if (!(toks[1] in this.prototypeLibrary[toks[0]].prototypes)) {
+                            annotations.addAnnotation(
+                                nodeRow,
+                                nodeName +  ': unknown prototype'
+                            );
+                        }
+                    }
+                }
+            }
+            if (typeof node.prototype === 'undefined' && (typeof node.config === 'undefined' || typeof node.class === 'undefined')) {
+                annotations.addAnnotation(
+                    nodeRow,
+                    nodeName +  ': prototype field or class and config fields should be defined'
+                );
+            }
+        });
+
+        if (Object.keys(this.pconfig).length > 1) {
+            annotations.addAnnotation(
+                0,
+                'Unknown top level attributes: ' + Object.keys(this.pconfig).filter((a: string) => { return a !== 'nodes'; }).join(' ,')
+            );
+        }
+
+        this.numAnnotations = annotations.length();
+        this.firstAnnotation = annotations.firstRowNumber();
+        if (annotations.length() !== 0) {
+            this.editor.getSession().setAnnotations(
+                annotations.getAnnotations()
+            );
+
+            return false;
+        }
+
+        this.valid = true;
+
+        return true;
+    }
+
+    errorClick(): void {
+        this.editor.gotoLine(this.firstAnnotation, 0, true);
+    }
+
+    append(): void {
+        var numRow: number;
+        var duplicate: boolean = false;
+        var annotations: ConfigAnnotations = new ConfigAnnotations();
+        var node: IMinemeldConfigNode;
+
+        this.processing = true;
+
+        for (node of this.MinemeldConfigService.nodesConfig) {
+            if (node.name in this.pconfig.nodes) {
+                duplicate = true;
+                numRow = this.findNode(node.name);
+                annotations.addAnnotation(
+                    numRow,
+                    'Node with name ' + node.name + ' already exists in candidate config, please rename'
+                );
+            }
+        }
+        if (duplicate) {
+            this.editor.getSession().setAnnotations(annotations.getAnnotations());
+            this.toastr.error('ERROR APPENDING CONFIG: NAME CONFLICTS');
+            this.processing = false;
+            return;
+        }
+
+        this.appendNodes().then(() => {
+            this.toastr.success('CONFIG APPENDED');
+
+            delete this['editor'];
+            this.$modalInstance.close('ok');
+            this.processing = false;
+        }, (error: any) => {
+            this.toastr.error('ERROR ADDING NODES: ' + error.statusText);
+            this.processing = false;
+        });
+    }
+
+    replace(): void {
+        this.processing = true;
+
+        this.ConfirmService.show(
+            'REPLACE CONFIG',
+            'REPLACE EXISTING CANDIDATE CONFIG ?'
+        ).then((result: any) => {
+            this.deleteAllNodes().then((result: any) => {
+                return this.appendNodes()
+                    .then((result: any) => {
+                        this.toastr.success('CANDIDATE CONFIG REPLACED');
+                        this.processing = false;
+
+                        delete this['editor'];
+                        this.$modalInstance.close('ok');
+                    }, (error: any) => {
+                        this.toastr.error('ERROR REPLACING CONFIG: ' + error.statusText);
+                        this.processing = false;
+                    });
+            });
+        }, (error: any) => {
+            this.processing = false;
+        });
+    }
+
+    cancel(): void {
+        delete this['editor'];
+
+        this.$modalInstance.dismiss();
+    }
+
+    private deleteAllNodes(): angular.IPromise<any> {
+        return this.MinemeldConfigService.nodesConfig.reduce((prevPromise: angular.IPromise<any>, currentNode: IMinemeldConfigNode, currentIndex: number) => {
+            if (currentNode.deleted) {
+                return prevPromise;
+            }
+
+            return prevPromise.then((result: any) => {
+                return this.MinemeldConfigService.deleteNode(currentIndex);
+            });
+        }, this.$q.when('<delete-all>'));
+    }
+
+    private appendNodes(): angular.IPromise<any> {
+        return Object.keys(this.pconfig.nodes).reduce((prevPromise: angular.IPromise<any>, currentName: string) => {
+            return prevPromise.then((result: any) => {
+                return this.MinemeldConfigService.addNode(currentName, this.pconfig.nodes[currentName]);
+            });
+        }, this.$q.when('<append>'));
+    }
+
+    private findNode(nodename: any): any {
+        var clines: string[];
+        var line: string;
+        var regexp: RegExp = new RegExp('^\\s+' +  nodename + ':\s*$');
+
+        clines = this.config.split('\n');
+        for (var row in clines) {
+            line = clines[row];
+            if (regexp.test(line)) {
+                return row;
+            }
+        }
+
+        return 0;
+    }
+}

--- a/src/app/config/configureexport.modal.html
+++ b/src/app/config/configureexport.modal.html
@@ -1,0 +1,24 @@
+<div class="modal-header">
+    <h1 class="modal-title">EXPORT CANDIDATE CONFIGURATION</h1>
+</div>
+<div class="modal-body">
+    <div class="row">
+        <div class="col-xs-2">
+            CONFIG
+        </div>
+        <div class="col-xs-10">
+            <div class="prototypeadd-ace-editor form-control" ng-readonly="true" ng-model="vm.config" ui-ace="{
+                useWrapMode : false,
+                showGutter: true,
+                theme:'github',
+                mode: 'yaml',
+                firstLineNumber: 1,
+                onLoad: vm.editorLoaded
+            }"></div>
+        </div>
+    </div>
+</div>
+<div class="modal-footer">
+    <button class="btn btn-primary btn-sm" type="button" ng-click="vm.copyToClipboard()">COPY TO CLIPBOARD</button>
+    <button class="btn btn-primary btn-sm" type="button" ng-click="vm.ok()">OK</button>
+</div>

--- a/src/app/config/configureimport.modal.html
+++ b/src/app/config/configureimport.modal.html
@@ -1,0 +1,27 @@
+<div class="modal-header">
+    <h1 class="modal-title">IMPORT CONFIGURATION</h1>
+</div>
+<div class="modal-body">
+    <div ng-class="['row', {'has-error': !vm.syntaxValid }]">
+        <div class="col-xs-2">
+            CONFIG
+        </div>
+        <div class="col-xs-10">
+            <div class="prototypeadd-ace-editor form-control" ng-readonly="vm.processing" ng-model="vm.config" ui-ace="{
+                useWrapMode : false,
+                showGutter: true,
+                theme:'github',
+                mode: 'yaml',
+                firstLineNumber: 1,
+                onLoad: vm.editorLoaded,
+                onChange: vm.aceChanged
+            }"></div>
+        </div>
+    </div>
+</div>
+<div class="modal-footer">
+    <button ng-if="vm.numAnnotations !== 0" class="btn btn-modal-action btn-sm" style="float: left;" ng-click="vm.errorClick()"><span class="glyphicon glyphicon glyphicon-remove-sign text-danger"></span> <span ng-bind="vm.numAnnotations"></span></button>
+    <button ng-disabled="!vm.valid || vm.processing" class="btn btn-primary btn-sm" type="button" ng-click="vm.append()">APPEND</button>
+    <button ng-disabled="!vm.valid || vm.processing" class="btn btn-primary btn-sm" type="button" ng-click="vm.replace()">REPLACE</button>
+    <button ng-disabled="vm.processing" class="btn btn-warning btn-sm" type="button" ng-click="vm.cancel()">CANCEL</button>
+</div>

--- a/src/app/config/configureinputs.modal.html
+++ b/src/app/config/configureinputs.modal.html
@@ -1,5 +1,5 @@
 <div class="modal-header">
-    <h1 class="modal-title">{{ vm.nodeConfig.name }} <span ng-if="vm.originalOutput != vm.output">*</span></h1>
+    <h1 class="modal-title">{{ vm.nodeConfig.name }} <span ng-if="vm.changed">*</span></h1>
 </div>
 <div class="modal-body">
     <div class="row">
@@ -8,15 +8,24 @@
         </div>
         <div class="col-xs-10">
             <ui-select multiple ng-model="vm.inputs" theme="bootstrap" on-select="vm.hasChanged()" on-remove="vm.hasChanged()">
-                <ui-select-match placeholder="Select inputs...">{{$item}}</ui-select-match>
-                <ui-select-choices repeat="input in vm.availableInputs | filter:$select.search">
-                    {{input}}
+                <ui-select-match placeholder="Select input nodes...">{{$item.name}}</ui-select-match>
+                <ui-select-choices group-by="'nodeType'" repeat="input.name as input in vm.availableInputs | filter: {'name':$select.search}">
+                    <div>
+                        <span ng-bind-html="input.name | highlight: $select.search"></span>
+                    </div>
                 </ui-select-choices>
+                <ui-select-no-choice><i>{{ vm.noChoiceMessage }}</i></ui-select-no-choice>
             </ui-select>
         </div>
     </div>
 </div>
 <div class="modal-footer">
+    <button ng-if="!vm.expertMode" tooltip-popup-delay="500" tooltip="enable expert mode" type="button" style="float: left;" class="btn btn-modal-action btn-sm" ng-click="vm.toggleExpert()">
+        <span class="glyphicon glyphicon-eye-open"></span>
+    </button>
+    <button ng-if="vm.expertMode" tooltip-popup-delay="500" tooltip="disable expert mode" type="button" style="float: left;" class="btn btn-modal-action btn-sm" ng-click="vm.toggleExpert()">
+        <span class="glyphicon glyphicon-eye-close"></span>
+    </button>
     <button ng-disabled="!vm.changed" class="btn btn-primary btn-sm" type="button" ng-click="vm.save()">OK</button>
     <button class="btn btn-warning btn-sm" type="button" ng-click="vm.cancel()">CANCEL</button>
 </div>

--- a/src/app/config/view.html
+++ b/src/app/config/view.html
@@ -3,6 +3,12 @@
     <button tooltip-popup-delay="500" tooltip="commit config" type="button" class="btn btn-primary btn-sm" ng-disabled="(vm.changed === false) || vm.inCommit" ng-click="vm.commit()">
         <span class="glyphicon glyphicon-save"></span> COMMIT
     </button>
+    <button tooltip-popup-delay="500" tooltip="export config" type="button" class="config-action btn btn-config-action btn-sm" ng-click="vm.export()">
+        <span class="glyphicon glyphicon-export"></span> EXPORT
+    </button>
+    <button tooltip-popup-delay="500" tooltip="import config" type="button" class="config-action btn btn-config-action btn-sm" ng-click="vm.import()">
+        <span class="glyphicon glyphicon-import"></span> IMPORT
+    </button>
     <button tooltip-popup-delay="500" tooltip="load committed config" type="button" class="config-action btn btn-config-action btn-sm" ng-click="vm.load()">
         <span class="glyphicon glyphicon-refresh"></span> LOAD
     </button>
@@ -17,10 +23,20 @@
         dt-columns="vm.dtColumns" class="table table-condensed">
         <tfoot>
             <tr>
-                <td colspan="7" style="padding-right: 0;">
+                <td colspan="3" style="padding-left: 0;">
+                    <div class="btn-toolbar" style="float: left;">
+                        <button ng-if="!vm.expertMode" tooltip-popup-delay="500" tooltip="enable expert mode" type="button" class="btn btn-config-action btn-sm" ng-click="vm.toggleExpert()">
+                            <span class="glyphicon glyphicon-eye-open"></span>
+                        </button>
+                        <button ng-if="vm.expertMode" tooltip-popup-delay="500" tooltip="disable expert mode" type="button" class="btn btn-config-action btn-sm" ng-click="vm.toggleExpert()">
+                            <span class="glyphicon glyphicon-eye-close"></span>
+                        </button>
+                    </div>
+                </td>
+                <td colspan="4" style="padding-right: 0;">
                     <div class="btn-toolbar" style="float: right;">
                         <button tooltip-popup-delay="500" tooltip="browse prototypes" class="btn btn-primary btn-sm" type="button" ng-click="vm.$state.go('prototypes')"><span class="glyphicon glyphicon-menu-hamburger"></span></button>
-                        <button tooltip-popup-delay="500" tooltip="add node" class="btn btn-primary btn-sm" type="button" ng-click="vm.$state.go('configadd')"><span class="glyphicon glyphicon-plus"></span></button>
+                        <button ng-if="vm.expertMode" tooltip-popup-delay="500" tooltip="add node" class="btn btn-primary btn-sm" type="button" ng-click="vm.$state.go('configadd')"><span class="glyphicon glyphicon-plus"></span></button>
                     </div>
                 </td>
             </tr>

--- a/src/app/index.module.ts
+++ b/src/app/index.module.ts
@@ -14,6 +14,8 @@ import { PrototypesController } from './prototypes/prototypes.controller';
 import { PrototypedetailController } from './prototypedetail/prototypedetail.controller';
 import { PrototypeAddController } from './prototypeadd/prototypeadd.controller';
 import { ConfigController } from './config/config.controller';
+import { ConfigureImportController } from './config/configimport.controller';
+import { ConfigureExportController } from './config/configexport.controller';
 import { ConfigAddController } from './config/configadd.controller';
 import { AboutController } from './about/about.controller';
 import { IndicatorAddController } from './indicatoradd/indicatoradd.controller';
@@ -31,6 +33,7 @@ import { MinemeldSupervisorService } from './services/supervisor';
 import { ConfirmService } from './services/confirm';
 import { MinemeldEventsService } from './services/events';
 import { MinemeldTracedService } from './services/traced';
+import { ThrottleService } from './services/throttle';
 import { megaNumber } from './filters/megaNumber';
 import { minemeldOptions } from '../app/components/options/options.directive';
 import { nodeConfig } from '../app/components/nodeconfig/nodeconfig.directive';
@@ -75,6 +78,8 @@ module minemeldWebui {
   .controller('PrototypedetailController', PrototypedetailController)
   .controller('PrototypeAddController', PrototypeAddController)
   .controller('ConfigController', ConfigController)
+  .controller('ConfigureImportController', ConfigureImportController)
+  .controller('ConfigureExportController', ConfigureExportController)
   .controller('ConfigAddController', ConfigAddController)
   .controller('IndicatorAddController', IndicatorAddController)
   .controller('AboutController', AboutController)
@@ -94,6 +99,7 @@ module minemeldWebui {
   .service('MinemeldValidateService', MinemeldValidateService)
   .service('MinemeldEventsService', MinemeldEventsService)
   .service('MinemeldTracedService', MinemeldTracedService)
+  .service('ThrottleService', ThrottleService)
   .filter('megaNumber', megaNumber)
   .run(minemeldInit)
   ;

--- a/src/app/nodedetail/autofocus.exportlist.controller.ts
+++ b/src/app/nodedetail/autofocus.exportlist.controller.ts
@@ -4,6 +4,7 @@ import { INodeDetailResolverService } from '../../app/services/nodedetailresolve
 import { IMinemeldConfigService } from '../../app/services/config';
 import { NodeDetailInfoController } from './nodedetail.info.controller';
 import { IMinemeldStatusService } from  '../../app/services/status';
+import { IThrottleService } from '../../app/services/throttle';
 
 /** @ngInject */
 function autofocusExportListConfig($stateProvider: ng.ui.IStateProvider) {
@@ -53,13 +54,14 @@ class NodeDetailAutofocusELInfoController extends NodeDetailInfoController {
         $compile: angular.ICompileService, $state: angular.ui.IStateService,
         $stateParams: angular.ui.IStateParamsService, MinemeldConfigService: IMinemeldConfigService,
         $modal: angular.ui.bootstrap.IModalService,
-        $rootScope: angular.IRootScopeService, $timeout: angular.ITimeoutService) {
+        $rootScope: angular.IRootScopeService,
+        ThrottleService: IThrottleService) {
         this.MinemeldConfigService = MinemeldConfigService;
         this.$modal = $modal;
 
         super(
             toastr, $interval, MinemeldStatusService, moment, $scope,
-            $compile, $state, $stateParams, $rootScope, $timeout
+            $compile, $state, $stateParams, $rootScope, ThrottleService
         );
 
         this.loadSideConfig();

--- a/src/app/nodedetail/credentials.controller.ts
+++ b/src/app/nodedetail/credentials.controller.ts
@@ -4,6 +4,7 @@ import { INodeDetailResolverService } from '../../app/services/nodedetailresolve
 import { IMinemeldConfigService } from '../../app/services/config';
 import { NodeDetailInfoController } from './nodedetail.info.controller';
 import { IMinemeldStatusService } from  '../../app/services/status';
+import { IThrottleService } from '../../app/services/throttle';
 
 /** @ngInject */
 function credentialsListConfig($stateProvider: ng.ui.IStateProvider) {
@@ -149,10 +150,11 @@ class NodeDetailCredentialsInfoController extends NodeDetailInfoController {
         $compile: angular.ICompileService, $state: angular.ui.IStateService,
         $stateParams: angular.ui.IStateParamsService, MinemeldConfigService: IMinemeldConfigService,
         $modal: angular.ui.bootstrap.IModalService,
-        $rootScope: angular.IRootScopeService, $timeout: angular.ITimeoutService) {
+        $rootScope: angular.IRootScopeService,
+        ThrottleService: IThrottleService) {
         super(
             toastr, $interval, MinemeldStatusService, moment, $scope,
-            $compile, $state, $stateParams, $rootScope, $timeout
+            $compile, $state, $stateParams, $rootScope, ThrottleService
         );
 
         this.MinemeldConfigService = MinemeldConfigService;
@@ -265,11 +267,11 @@ class NodeDetailCredentialsInfoController extends NodeDetailInfoController {
             this.username = result.username;
 
             return this.saveSideConfig();
+        }, (error: any) => {
+            this.toastr.error('ERROR SETTING USERNAME: ' + error.statusText);
         })
         .then((result: any) => {
             this.toastr.success('USERNAME SET');
-        }, (error: any) => {
-            this.toastr.error('ERROR SETTING USERNAME: ' + error.status);
         });
     }
 }

--- a/src/app/nodedetail/proofpoint.controller.ts
+++ b/src/app/nodedetail/proofpoint.controller.ts
@@ -4,6 +4,7 @@ import { INodeDetailResolverService } from '../../app/services/nodedetailresolve
 import { IMinemeldConfigService } from '../../app/services/config';
 import { NodeDetailInfoController } from './nodedetail.info.controller';
 import { IMinemeldStatusService } from  '../../app/services/status';
+import { IThrottleService } from '../../app/services/throttle';
 
 class ET {
     static CATNAMES: string[] = [
@@ -126,10 +127,11 @@ class NodeDetailProofpointInfoController extends NodeDetailInfoController {
         $compile: angular.ICompileService, $state: angular.ui.IStateService,
         $stateParams: angular.ui.IStateParamsService, MinemeldConfigService: IMinemeldConfigService,
         $modal: angular.ui.bootstrap.IModalService,
-        $rootScope: angular.IRootScopeService, $timeout: angular.ITimeoutService) {
+        $rootScope: angular.IRootScopeService,
+        ThrottleService: IThrottleService) {
         super(
             toastr, $interval, MinemeldStatusService, moment, $scope,
-            $compile, $state, $stateParams, $rootScope, $timeout
+            $compile, $state, $stateParams, $rootScope, ThrottleService
         );
 
         this.MinemeldConfigService = MinemeldConfigService;

--- a/src/app/nodedetail/recordedfuture.controller.ts
+++ b/src/app/nodedetail/recordedfuture.controller.ts
@@ -4,6 +4,7 @@ import { INodeDetailResolverService } from '../../app/services/nodedetailresolve
 import { IMinemeldConfigService } from '../../app/services/config';
 import { NodeDetailInfoController } from './nodedetail.info.controller';
 import { IMinemeldStatusService } from  '../../app/services/status';
+import { IThrottleService } from '../../app/services/throttle';
 
 /** @ngInject */
 function recordedFutureRouterConfig($stateProvider: ng.ui.IStateProvider) {
@@ -52,13 +53,14 @@ class NodeDetailRecordedFutureInfoController extends NodeDetailInfoController {
         $compile: angular.ICompileService, $state: angular.ui.IStateService,
         $stateParams: angular.ui.IStateParamsService, MinemeldConfigService: IMinemeldConfigService,
         $modal: angular.ui.bootstrap.IModalService,
-        $rootScope: angular.IRootScopeService, $timeout: angular.ITimeoutService) {
+        $rootScope: angular.IRootScopeService,
+        ThrottleService: IThrottleService) {
         this.MinemeldConfigService = MinemeldConfigService;
         this.$modal = $modal;
 
         super(
             toastr, $interval, MinemeldStatusService, moment, $scope,
-            $compile, $state, $stateParams, $rootScope, $timeout
+            $compile, $state, $stateParams, $rootScope, ThrottleService
         );
 
         this.loadToken();

--- a/src/app/nodedetail/threatq.export.controller.ts
+++ b/src/app/nodedetail/threatq.export.controller.ts
@@ -5,6 +5,7 @@ import { IMinemeldConfigService } from '../../app/services/config';
 import { NodeDetailInfoController } from './nodedetail.info.controller';
 import { IMinemeldStatusService } from  '../../app/services/status';
 import { IConfirmService } from '../../app/services/confirm';
+import { IThrottleService } from '../../app/services/throttle';
 
 /** @ngInject */
 function threatqExportConfig($stateProvider: ng.ui.IStateProvider) {
@@ -54,7 +55,8 @@ class NodeDetailThreatQExportInfoController extends NodeDetailInfoController {
         moment: moment.MomentStatic, $scope: angular.IScope,
         $compile: angular.ICompileService, $state: angular.ui.IStateService,
         $stateParams: angular.ui.IStateParamsService, MinemeldConfigService: IMinemeldConfigService,
-        $rootScope: angular.IRootScopeService, $timeout: angular.ITimeoutService,
+        $rootScope: angular.IRootScopeService,
+        ThrottleService: IThrottleService,
         $modal: angular.ui.bootstrap.IModalService,
         ConfirmService: IConfirmService) {
         this.MinemeldConfigService = MinemeldConfigService;
@@ -63,7 +65,7 @@ class NodeDetailThreatQExportInfoController extends NodeDetailInfoController {
 
         super(
             toastr, $interval, MinemeldStatusService, moment, $scope,
-            $compile, $state, $stateParams, $rootScope, $timeout
+            $compile, $state, $stateParams, $rootScope, ThrottleService
         );
 
         this.loadSideConfig();

--- a/src/app/nodes/nodes.scss
+++ b/src/app/nodes/nodes.scss
@@ -49,20 +49,27 @@
 
 .nodes-dt-header-miner {
     background-color: $minemeld-miner !important;
+    width: 5px;
 }
 
 .nodes-dt-header-output {
     background-color: $minemeld-output !important;
+    width: 5px;
 }
 
 .nodes-dt-header-processor {
     background-color: $minemeld-processor !important;
+    width: 5px;
 }
 
 .nodes-dt-name {
     text-overflow: ellipsis;
     overflow: hidden;
     white-space: nowrap;
+}
+
+.nodes-dt-header-default {
+    background-color: $gray-light !important;
 }
 
 .nodes-label-miner {

--- a/src/app/services/config.ts
+++ b/src/app/services/config.ts
@@ -62,6 +62,8 @@ export class MinemeldConfigService implements IMinemeldConfigService {
         this.$state = $state;
         this.$q = $q;
         this.MineMeldAPIService = MineMeldAPIService;
+
+        this.MineMeldAPIService.onLogout(this.emptyCache.bind(this));
     }
 
     refresh() {
@@ -248,5 +250,11 @@ export class MinemeldConfigService implements IMinemeldConfigService {
             .then((result: any) => {
                 return result.result;
             });
+    }
+
+    private emptyCache(): void {
+        this.nodesConfig = undefined;
+        this.configInfo = undefined;
+        this.changed = undefined;
     }
 }

--- a/src/app/services/throttle.ts
+++ b/src/app/services/throttle.ts
@@ -1,0 +1,73 @@
+/// <reference path="../../../typings/main.d.ts" />
+
+/* Code based on
+     Underscore.js 1.8.3
+     http://underscorejs.org
+     (c) 2009-2016 Jeremy Ashkenas, DocumentCloud and Investigative Reporters & Editors
+     Underscore may be freely distributed under the MIT license.
+*/
+
+export interface IThrottled {
+    (): void;
+    cancel(): void;
+}
+
+export interface IThrottleService {
+    throttle(f: () => void, wait: number): IThrottled;
+}
+
+export class ThrottleService implements IThrottleService {
+    $timeout: angular.ITimeoutService;
+
+    /** @ngInject */
+    constructor($timeout: angular.ITimeoutService) {
+        this.$timeout = $timeout;
+    }
+
+    throttle(f: () => void, wait: number): IThrottled {
+        var timeout: angular.IPromise<any>;
+        var previous: number = 0;
+        var cancelled: boolean = false;
+        var vm: ThrottleService = this;
+
+        var later: () => void = function() {
+            previous = (new Date()).getTime();
+            timeout = null;
+
+            f();
+        };
+
+        var throttled: any = function() {
+            var now: number = (new Date()).getTime();
+            var remaining: number = wait - (now - previous);
+
+            if (cancelled) {
+                return;
+            }
+
+            if (remaining <= 0 || remaining > wait) {
+                if (timeout) {
+                    vm.$timeout.cancel(timeout);
+                    timeout = null;
+                }
+
+                previous = now;
+
+                f();
+            } else if (!timeout) {
+                timeout = vm.$timeout(later, remaining);
+            }
+        };
+
+        throttled.cancel = function(): void {
+            cancelled = true;
+            if (timeout) {
+                vm.$timeout.cancel(timeout);
+            }
+            previous = 0;
+            timeout = null;
+        };
+
+        return <IThrottled>throttled;
+    }
+}

--- a/src/app/styles/bootstrap-theme.scss
+++ b/src/app/styles/bootstrap-theme.scss
@@ -17,6 +17,10 @@
   padding-left: 10px;
 }
 
+.btn-modal-action {
+  @include button-variant(darken($body-bg, 80%), lighten($body-bg, 2%), lighten($body-bg, 2%));
+}
+
 .ui-select-bootstrap .ui-select-choices-row.active>a {
   background-color: darken($body-bg, 10%) !important;
   color: darken($body-bg, 80%);
@@ -27,8 +31,20 @@
   color: darken($body-bg, 80%);
 }
 
+.ui-select-bootstrap .ui-select-no-choice {
+  font-size: 12px !important;
+  color: darken($body-bg, 80%);
+  padding: 3px 20px;
+  font-style: italic;
+}
+
 .ui-select-multiple.ui-select-bootstrap .ui-select-match .close {
   line-height: 1 !important;
+}
+
+.ui-select-multiple.ui-select-bootstrap > div > input.ui-select-search[disabled] {
+    display: initial !important;
+    cursor: not-allowed;
 }
 
 .no-padding {
@@ -188,4 +204,8 @@ div.main-container {
   top: 100%;
   left: 0;
   text-align: center;
+}
+
+.dataTables_filter > label > input {
+    margin-left: 5px;
 }


### PR DESCRIPTION
- hidden output field in CONFIG view
- switched from POSITION to the less confusing TYPE in CONFIG view, to show the type of node (from prototype)
- CONFIG view now enforces a limit on the input nodes
- INPUTS for Miner are now grayed out
- all the enforced checks can be disabled enabling expert mode (eye icon)
- in CONFIG ADD, removed OUTPUT
- any time INPUTS should be selected, only suitable nodes are now proposed
- added CONFIG IMPORT
- added CONFIG EXPORT
- added Throttle Service to throttle updates to UI

Next step: add an alternative tab to use graph to configure processing flow.
