### PR TITLE
Added CIF miner support in nodedetail

### DIFF
--- a/src/app/nodedetail/cif.controller.ts
+++ b/src/app/nodedetail/cif.controller.ts
@@ -1,0 +1,432 @@
+/// <reference path="../../../typings/main.d.ts" />
+
+import { NodeDetailCredentialsInfoController } from './credentials.controller';
+import { INodeDetailResolverService } from '../../app/services/nodedetailresolver';
+import { IMinemeldConfigService } from '../../app/services/config';
+import { IMinemeldStatusService } from  '../../app/services/status';
+import { IThrottleService } from '../../app/services/throttle';
+import { IConfirmService } from '../../app/services/confirm';
+
+/** @ngInject */
+function CIFConfig($stateProvider: ng.ui.IStateProvider) {
+    $stateProvider
+        .state('nodedetail.cifinfo', {
+            templateUrl: 'app/nodedetail/cif.info.html',
+            controller: NodeDetailCIFInfoController,
+            controllerAs: 'nodedetailinfo',
+            params: {
+                usernameEnabled: {
+                    value: false
+                },
+                secretName: {
+                    value: 'TOKEN'
+                },
+                secretField: {
+                    value: 'token'
+                }
+            }
+        })
+        ;
+}
+
+/** @ngInject */
+function CIFRegisterClasses(NodeDetailResolver: INodeDetailResolverService) {
+    NodeDetailResolver.registerClass('minemeld.ft.cif.Feed', {
+        tabs: [{
+            icon: 'fa fa-circle-o',
+            tooltip: 'INFO',
+            state: 'nodedetail.cifinfo',
+            active: false
+        },
+        {
+            icon: 'fa fa-area-chart',
+            tooltip: 'STATS',
+            state: 'nodedetail.stats',
+            active: false
+        },
+        {
+            icon: 'fa fa-asterisk',
+            tooltip: 'GRAPH',
+            state: 'nodedetail.graph',
+            active: false
+        }]
+    });
+}
+
+interface ICIFSideConfigFilters {
+    tags?: string[];
+    otype?: string;
+    confidence?: number;
+    [key: string]: any
+}
+
+interface ICIFSideConfig {
+    verify_cert?: boolean;
+    remote?: string;
+    filters?: ICIFSideConfigFilters
+}
+
+class NodeDetailCIFInfoController extends NodeDetailCredentialsInfoController {
+    MinemeldConfigService: IMinemeldConfigService;
+    $modal: angular.ui.bootstrap.IModalService;
+    ConfirmService: IConfirmService;
+
+    remote: string;
+    flattenedFilters: string;
+    verify_cert: boolean;
+
+    private _filters: ICIFSideConfigFilters;
+
+    /* @ngInject */
+    constructor(toastr: any, $interval: angular.IIntervalService,
+        MinemeldStatusService: IMinemeldStatusService,
+        moment: moment.MomentStatic, $scope: angular.IScope,
+        $compile: angular.ICompileService, $state: angular.ui.IStateService,
+        $stateParams: angular.ui.IStateParamsService, MinemeldConfigService: IMinemeldConfigService,
+        $modal: angular.ui.bootstrap.IModalService,
+        $rootScope: angular.IRootScopeService,
+        ThrottleService: IThrottleService,
+        ConfirmService: IConfirmService) {
+        super(
+            toastr, $interval, MinemeldStatusService, moment, $scope,
+            $compile, $state, $stateParams, MinemeldConfigService, $modal,
+            $rootScope, ThrottleService
+        );
+
+        this.ConfirmService = ConfirmService;
+    }
+
+    setRemote(): void {
+        var mi: angular.ui.bootstrap.IModalServiceInstance;
+
+        mi = this.$modal.open({
+            templateUrl: 'app/nodedetail/cif.remote.modal.html',
+            controller: CIFSetRemoteController,
+            controllerAs: 'vm',
+            bindToController: true,
+            backdrop: 'static',
+            animation: false,
+            resolve: {
+                remote: () => { return this.remote; }
+            }
+        });
+
+        mi.result.then((result: any) => {
+            this.remote = result.remote;
+
+            return this.saveSideConfig().then((result: any) => {
+                this.toastr.success('REMOTE SET');
+            }, (error: any) => {
+                this.toastr.error('ERROR SETTING REMOTE: ' + error.statusText);
+            });
+        });
+    }
+
+    toggleCertificateVerification(): void {
+        var p: angular.IPromise<any>;
+        var new_value: boolean;
+
+        if (typeof this.verify_cert === 'undefined' || this.verify_cert) {
+            new_value = false;
+            p = this.ConfirmService.show(
+                'CIF REMOTE CERT VERIFICATION',
+                'Are you sure you want to disable certificate verification ?'
+            );
+        } else {
+            new_value = true;
+            p = this.ConfirmService.show(
+                'CIF REMOTE CERT VERIFICATION',
+                'Are you sure you want to enable certificate verification ?'
+            );
+        }
+
+        p.then((result: any) => {
+            this.verify_cert = new_value;
+
+            return this.saveSideConfig().then((result: any) => {
+                this.toastr.success('CERT VERIFICATION TOGGLED');
+            }, (error: any) => {
+                this.toastr.error('ERROR TOGGLING CERT VERIFICATION: ' + error.statusText);
+            });
+        });
+    }
+
+    setFilters(): void {
+        var mi: angular.ui.bootstrap.IModalServiceInstance;
+
+        mi = this.$modal.open({
+            templateUrl: 'app/nodedetail/cif.filters.modal.html',
+            controller: CIFSetFiltersController,
+            controllerAs: 'vm',
+            bindToController: true,
+            backdrop: 'static',
+            animation: false,
+            resolve: {
+                filters: () => { return this.filters; }
+            }
+        });
+
+        mi.result.then((result: any) => {
+            this.filters = result.filters;
+
+            return this.saveSideConfig().then((result: any) => {
+                this.toastr.success('FILTERS SET');
+            }, (error: any) => {
+                this.toastr.error('ERROR SETTING FILTERS: ' + error.statusText);
+            });
+        });
+    }
+
+    protected restoreSideConfig(result: any) {
+        let side_config = <ICIFSideConfig>result;
+
+        super.restoreSideConfig(result);
+
+        this.remote = undefined;
+        this.filters = undefined;
+        this.verify_cert = undefined;
+
+        console.log(side_config);
+
+        if (!result) {
+            return;
+        }
+
+        if (side_config.remote) {
+            this.remote = side_config.remote;
+        }
+
+        if (side_config.filters) {
+            this.filters = side_config.filters;
+        }
+
+        if (typeof side_config.verify_cert !== 'undefined') {
+            this.verify_cert = side_config.verify_cert;
+        }
+    }
+
+    protected prepareSideConfig(): any {
+        var side_config: any = super.prepareSideConfig();
+
+        if (this.remote) {
+            side_config.remote = this.remote;
+        }
+
+        if (this.filters) {
+            side_config.filters = this.filters;
+        }
+
+        if (typeof this.verify_cert !== 'undefined') {
+            side_config.verify_cert = this.verify_cert;
+        }
+
+        console.log(side_config);
+
+        return side_config;
+    }
+
+    get filters(): ICIFSideConfigFilters {
+        return this._filters;
+    }
+
+    set filters(newfilters: ICIFSideConfigFilters) {
+        this._filters = newfilters;
+        this.flattenFilters();
+    }
+
+    private flattenFilters(): void {
+        var filter: string[] = [];
+
+        if (!this.filters) {
+            this.flattenedFilters = undefined;
+            return;
+        }
+
+        Object.keys(this.filters).forEach((key: string) => {
+            var value: any;
+            var kv: string;
+
+            kv = key + ': ';
+            value = this.filters[key];
+
+            if (value instanceof Array) {
+                kv += value.join(', ');
+            } else {
+                kv += value;
+            }
+
+            filter.push(kv);
+        });
+
+        this.flattenedFilters = filter.join(' ');
+
+        console.log(this.flattenedFilters);
+    }
+}
+
+class CIFSetRemoteController {
+    $modalInstance: angular.ui.bootstrap.IModalServiceInstance;
+
+    remote: string;
+
+    /** @ngInject */
+    constructor($modalInstance: angular.ui.bootstrap.IModalServiceInstance, remote: string) {
+        this.$modalInstance = $modalInstance;
+        this.remote = remote;
+    }
+
+    valid(): boolean {
+        if (!this.remote) {
+            return false;
+        }
+
+        return true;
+    }
+
+    save() {
+        var result: any = {};
+
+        result.remote = this.remote;
+
+        this.$modalInstance.close(result);
+    }
+
+    cancel() {
+        this.$modalInstance.dismiss();
+    }
+};
+
+class CIFSetFiltersController {
+    $modalInstance: angular.ui.bootstrap.IModalServiceInstance;
+
+    otypes: string[] = [
+        'ipv4',
+        'ipv6',
+        'fqdn',
+        'url'
+    ];
+
+    defaultTags: string[] = [
+        'whitelist',
+        'spam',
+        'malware',
+        'scanner',
+        'hijacked',
+        'botnet',
+        'exploit',
+        'phishing'
+    ];
+
+    filters: ICIFSideConfigFilters;
+    otype: string;
+    confidence: string;
+    confidenceValid: boolean = true;
+    tags: string[];
+    changed: boolean;
+
+    /** @ngInject */
+    constructor($modalInstance: angular.ui.bootstrap.IModalServiceInstance,
+                filters: ICIFSideConfigFilters) {
+        this.$modalInstance = $modalInstance;
+        this.filters = filters;
+
+        if (this.filters) {
+            if (this.filters.otype) {
+                this.otype = this.filters.otype;
+            }
+            if (typeof this.filters.confidence !== 'undefined') {
+                this.confidence = ''+this.filters.confidence;
+            }
+            if (typeof this.filters.tags !== 'undefined') {
+                this.tags = this.filters.tags;
+            }
+        }
+    }
+
+    tagging(value: any): any {
+        return value;
+    }
+
+    valid(): boolean {
+        var result: boolean = true;
+        var nconfidence: number;
+
+        if (!this.changed) {
+            result = false;
+        }
+
+        angular.element('#fgConfidence').removeClass('has-error');
+        if (typeof this.confidence !== 'undefined' && this.confidence.length !== 0) {
+            if (!/^\s*[0-9]+\s*$/.test(this.confidence)) {
+                result = false;
+                angular.element('#fgConfidence').addClass('has-error');
+            } else {
+                nconfidence = +this.confidence;
+                if (nconfidence < 0 || nconfidence > 100 || isNaN(nconfidence)) {
+                    result = false;
+                    angular.element('#fgConfidence').addClass('has-error');
+                }
+            }
+        }
+
+        return result;
+    }
+
+    save() {
+        var result: any = {};
+
+        result.filters = this.filters;
+
+        if (typeof this.confidence !== 'undefined' && this.confidence.length !== 0) {
+            if (!result.filters) {
+                result.filters = {};
+            }
+
+            result.filters.confidence = +this.confidence;
+        } else {
+            if (result.filters) {
+                delete result.filters.confidence;
+            }
+        }
+
+        if (typeof this.tags !== 'undefined' && this.tags.length !== 0) {
+            if (!result.filters) {
+                result.filters = {};
+            }
+
+            result.filters.tags = this.tags;
+        } else {
+            if (result.filters) {
+                delete result.filters.tags;
+            }
+        }
+
+        if (typeof this.otype !== 'undefined' && this.otype.length !== 0) {
+            if (!result.filters) {
+                result.filters = {};
+            }
+
+            result.filters.otype = this.otype;
+        } else {
+            if (result.filters) {
+                delete result.filters.otype;
+            }
+        }
+
+        if (Object.keys(result.filters).length === 0) {
+            result.filters = undefined;
+        }
+
+        this.$modalInstance.close(result);
+    }
+
+    cancel() {
+        this.$modalInstance.dismiss();
+    }
+};
+
+console.log('Loading CIF');
+angular.module('minemeldWebui')
+    .config(CIFConfig)
+    .run(CIFRegisterClasses)
+    ;

--- a/src/app/nodedetail/cif.filters.modal.html
+++ b/src/app/nodedetail/cif.filters.modal.html
@@ -1,0 +1,52 @@
+<div class="modal-header">
+    <h1 class="modal-title">CIF FILTERS <span ng-if="vm.changed">*</span></h1>
+</div>
+<div class="modal-body">
+    <div class="row">
+        <form class="config-add-form form-horizontal m-t-xs">
+            <div class="form-group" id="fgOtype">
+                <label class="col-xs-4 control-label">OTYPE</label>
+                <div class="col-xs-6">
+                    <ui-select ng-model="vm.otype"
+                               theme="bootstrap"
+                               reset-search-input="false"
+                               style="width: 100%;"
+                               on-select="vm.changed = true"
+                               on-remove="vm.changed = true">
+                        <ui-select-match placeholder="Not set">{{$select.selected}}</ui-select-match>
+                        <ui-select-choices repeat="otype in vm.otypes | filter: $select.search">
+                            <span ng-bind-html="otype | highlight: $select.search"></span>
+                        </ui-select-choices>
+                    </ui-select>
+                </div>
+            </div>
+            <div class="form-group" id="fgConfidence">
+                <label class="col-xs-4 control-label">CONFIDENCE</label>
+                <div class="col-xs-6">
+                    <div class="input-group">
+                        <div class="input-group-addon">&gt;=</div>
+                        <input type="text" class="form-control" ng-change="vm.changed = true" placeholder="Not set" ng-model="vm.confidence">
+                    </div>
+                </div>
+            </div>
+            <div class="form-group" id="fgTags">
+                <label class="col-xs-4 control-label">TAGS</label>
+                <div class="col-xs-6">
+                    <ui-select multiple ng-model="vm.tags" theme="bootstrap" tagging="vm.tagging"
+                                on-select="vm.changed = true" on-remove="vm.changed = true">
+                        <ui-select-match placeholder="Not set">{{$item}}</ui-select-match>
+                        <ui-select-choices repeat="tag as tag in vm.defaultTags | filter: $select.search">
+                            <div>
+                                <span ng-bind-html="tag | highlight: $select.search"></span>
+                            </div>
+                        </ui-select-choices>
+                </ui-select>
+                </div>
+            </div>
+        </form>
+    </div>
+</div>
+<div class="modal-footer">
+    <button ng-disabled="!vm.valid()" class="btn btn-primary btn-sm" type="button" ng-click="vm.save()">OK</button>
+    <button class="btn btn-warning btn-sm" type="button" ng-click="vm.cancel()">CANCEL</button>
+</div>

--- a/src/app/nodedetail/cif.info.html
+++ b/src/app/nodedetail/cif.info.html
@@ -1,0 +1,114 @@
+<div class="row">
+    <div class="col-sm-12 col-md-12">
+        <h5 class="m-b-xs">STATUS</h5>
+    </div>
+</div>
+<div class="row">
+    <div class="col-sm-6 col-md-6">
+        <table class="table table-condensed nodedetail-info-table">
+            <colgroup>
+                <col style="width: 30%">
+                <col>
+            </colgroup>
+            <tbody>
+                <tr>
+                    <td>CLASS</td>
+                    <td>{{ nodedetailinfo.nodeState.class }}</td>
+                </tr>
+                <tr ng-if="nodedetailinfo.nodeConfig.prototype">
+                    <td>PROTOTYPE</td>
+                    <td><a tooltip-template="'tooltip.prototype.html'" ui-sref="prototypedetail({ prototypeName: nodedetailinfo.nodeConfig.prototype.split('.')[1], libraryName: nodedetailinfo.nodeConfig.prototype.split('.')[0] })">{{ nodedetailinfo.nodeConfig.prototype }}</a></td>
+                    <script type="text/ng-template" id="tooltip.prototype.html">
+                        <prototype-tooltip name="nodedetailinfo.nodeConfig.prototype"></prototype-tooltip>
+                    </script>
+                </tr>
+                <tr>
+                    <td>STATE</td>
+                    <td ng-switch on="nodedetailinfo.nodeState.state">
+                        <span ng-switch-when="5" class="label label-success">{{ nodedetailinfo.nodeState.stateAsString }}</span>
+                        <span ng-switch-default class="label label-warning">{{ nodedetailinfo.nodeState.stateAsString }}</span>
+                    </td>
+                </tr>
+                <tr>
+                    <td>REMOTE</td>
+                    <td tooltip="set remote" class="nodedetail-info-clickable" ng-click="nodedetailinfo.setRemote()">
+                        <span ng-if="!nodedetailinfo.remote"><em>Not set</em></span>
+                        <span ng-if="nodedetailinfo.remote">{{ nodedetailinfo.remote }}</span>
+                    </td>
+                </tr>
+                <tr>
+                    <td>VERIFY CERT</td>
+                    <td tooltip="toggle Cert Verification" class="nodedetail-info-clickable" ng-click="nodedetailinfo.toggleCertificateVerification()">
+                        <span ng-if="nodedetailinfo.verify_cert === undefined" class="label label-success"><em>Not set</em></span>
+                        <span ng-if="nodedetailinfo.verify_cert !== undefined && !nodedetailinfo.verify_cert" class="label label-default"><span class="glyphicon glyphicon-remove" aria-hidden="true"></span></span>
+                        <span ng-if="nodedetailinfo.verify_cert" class="label label-success"><span class="glyphicon glyphicon-ok" aria-hidden="true"></span></span>
+                    </td>
+                </tr>
+                <tr>
+                    <td>TOKEN</td>
+                    <td tooltip="set {{ vm.secretName|lowercase }}" class="nodedetail-info-clickable" ng-click="nodedetailinfo.setPassword()">
+                        <span ng-if="!nodedetailinfo.secret"><em>Not set</span></span>
+                        <span ng-if="nodedetailinfo.secret" class="label label-success"><span class="glyphicon glyphicon-ok" aria-hidden="true"></span></span>
+                    </td>
+                </tr>
+                <tr>
+                    <td>FILTERS</td>
+                    <td tooltip="set filter" class="nodedetail-info-clickable" ng-click="nodedetailinfo.setFilters()">
+                        <span ng-if="!nodedetailinfo.flattenedFilters"><em>Not set</span></span>
+                        <span ng-if="nodedetailinfo.flattenedFilters">{{ nodedetailinfo.flattenedFilters }}</span>
+                    </td>
+                </tr>
+                <tr ng-if="nodedetailinfo.nodeState.last_run">
+                    <td>LAST RUN</td>
+                    <td>
+                        <span ng-bind="nodedetailinfo.nodeState.last_run | date:'yyyy-MM-dd HH:mm:ss Z'"></span>
+                        <span ng-if="nodedetailinfo.nodeState.sub_state"
+                              ng-class="['label', {WAITING: 'label-default', POLLING:'label-primary', ERROR:'label-danger', SUCCESS:'label-success', REBUILDING:'label-warning'}[nodedetailinfo.nodeState.sub_state]]"
+                              ng-bind="nodedetailinfo.nodeState.sub_state"></span>
+                        <span tooltip="run now"
+                              tooltip-popup-delay="200"
+                              ng-if="nodedetailinfo.nodeState.sub_state != 'WAITING' && nodedetailinfo.nodeState.sub_state != 'REBUILDING' && nodedetailinfo.nodeState.sub_state != 'POLLING'"
+                              ng-click="nodedetailinfo.run()"
+                              class="nodedetail-info-icon fa fa-refresh"></span>
+                    </td>
+                </tr>
+                <tr>
+                    <td># INDICATORS</td>
+                    <td>{{ nodedetailinfo.nodeState.indicators }}</td>
+                </tr>
+            </tbody>
+        </table>
+    </div>
+    <div class="col-sm-6 col-md-6">
+        <table class="table table-condensed nodedetail-info-table">
+              <colgroup>
+                <col style="width: 15%">
+                <col style="width: 85%">
+            </colgroup>
+            <tbody>
+                <tr>
+                    <td>OUTPUT</td>
+                    <td>
+                        <span class="label label-success" ng-if="nodedetailinfo.nodeState.output">ENABLED</span>
+                        <span class="label label-default" ng-if="!nodedetailinfo.nodeState.output">DISABLED</span>
+                    </td>
+                </tr>
+                <tr>
+                    <td>INPUTS</td>
+                    <td>
+                        <ul class="nodetails-info-inputs" ng-if="nodedetailinfo.nodeState.inputs.length > 0">
+                            <li ng-repeat="input in nodedetailinfo.nodeState.inputs"><a ui-sref="nodedetail({ nodename: input })">{{ input }}</a></li>
+                        </ul>
+                        <em ng-if="nodedetailinfo.nodeState.inputs.length == 0">none</em>
+                    </td>
+                </tr>
+            </tbody>
+        </table>
+    </div>
+</div>
+<div class="row" ng-if="nodedetailinfo.nodeConfig.config">
+    <div class="col-sm-12 col-md-12">
+        <h5 class="m-b-xs">CONFIG</h5>
+        <node-config class="nodedetail-info-config" config="nodedetailinfo.nodeConfig.config"></node-config>
+    </div>
+</div>

--- a/src/app/nodedetail/cif.remote.modal.html
+++ b/src/app/nodedetail/cif.remote.modal.html
@@ -1,0 +1,19 @@
+<div class="modal-header">
+    <h1 class="modal-title">CIF REMOTE</h1>
+</div>
+<div class="modal-body">
+    <div class="row">
+        <form class="config-add-form form-horizontal m-t-xs">
+            <div class="form-group">
+                <label class="col-xs-4 control-label">REMOTE</label>
+                <div class="col-xs-6">
+                    <textarea ng-model="vm.url" rows="3" class="form-control" placeholder="CIF Remote URL"></textarea>
+                </div>
+            </div>
+        </form>
+    </div>
+</div>
+<div class="modal-footer">
+    <button ng-disabled="!vm.valid()" class="btn btn-primary btn-sm" type="button" ng-click="vm.save()">OK</button>
+    <button class="btn btn-warning btn-sm" type="button" ng-click="vm.cancel()">CANCEL</button>
+</div>

--- a/src/app/nodedetail/credentials.controller.ts
+++ b/src/app/nodedetail/credentials.controller.ts
@@ -133,7 +133,7 @@ function credentialsRegisterClasses(NodeDetailResolver: INodeDetailResolverServi
     });
 }
 
-class NodeDetailCredentialsInfoController extends NodeDetailInfoController {
+export class NodeDetailCredentialsInfoController extends NodeDetailInfoController {
     MinemeldConfigService: IMinemeldConfigService;
     secret: string;
     username: string;
@@ -175,25 +175,7 @@ class NodeDetailCredentialsInfoController extends NodeDetailInfoController {
 
     loadSideConfig(): void {
         this.MinemeldConfigService.getDataFile(this.nodename + '_side_config')
-        .then((result: any) => {
-            if (!result) {
-                this.username = undefined;
-                this.secret = undefined;
-
-                return;
-            }
-            if (result[this.secretField]) {
-                this.secret = result[this.secretField];
-            } else {
-                this.secret = undefined;
-            }
-
-            if (this.usernameEnabled && result.username) {
-                this.username = result.username;
-            } else {
-                this.username = undefined;
-            }
-        }, (error: any) => {
+        .then(this.restoreSideConfig.bind(this), (error: any) => {
             this.toastr.error('ERROR RETRIEVING NODE SIDE CONFIG: ' + error.status);
             this.secret = undefined;
             this.username = undefined;
@@ -201,19 +183,13 @@ class NodeDetailCredentialsInfoController extends NodeDetailInfoController {
     }
 
     saveSideConfig(): angular.IPromise<any> {
-        var side_config: any = {};
+        var side_config: any;
 
-        if (this.secret) {
-            side_config[this.secretField] = this.secret;
-        }
-        if (this.username && this.usernameEnabled) {
-            side_config.username = this.username;
-        }
+        side_config = this.prepareSideConfig();
 
         return this.MinemeldConfigService.saveDataFile(
             this.nodename + '_side_config',
-            side_config,
-            this.nodename
+            side_config
         );
     }
 
@@ -273,6 +249,40 @@ class NodeDetailCredentialsInfoController extends NodeDetailInfoController {
         .then((result: any) => {
             this.toastr.success('USERNAME SET');
         });
+    }
+
+    protected restoreSideConfig(result: any) {
+        if (!result) {
+            this.username = undefined;
+            this.secret = undefined;
+
+            return;
+        }
+
+        if (result[this.secretField]) {
+            this.secret = result[this.secretField];
+        } else {
+            this.secret = undefined;
+        }
+
+        if (this.usernameEnabled && result.username) {
+            this.username = result.username;
+        } else {
+            this.username = undefined;
+        }
+    }
+
+    protected prepareSideConfig(): any {
+        var side_config: any = {};
+
+        if (this.secret) {
+            side_config[this.secretField] = this.secret;
+        }
+        if (this.username && this.usernameEnabled) {
+            side_config.username = this.username;
+        }
+
+        return side_config;
     }
 }
 


### PR DESCRIPTION
## Motivation

A CIF Miner class has been added in minemeld-core, this
modifications are necessary to support the Miner on the
WebUI.

The CIF Miner WebUI lets you supply parameters necessary
for the CIF Miner operations, like remote address, token,
filters.

## Modifications

- Added a new controller in nodedetail to support minemeld.ft.cif.Feed
class. The new controller inherits from credentials controller.
- The credentials controller has been modified to permit subclasses
to customize what is saved inside the side config.
- Removed automatic hup from credentials controller.

## Result

When a node of class minemeld.ft.cif.Feed is used the WebUI can be used
to supply side config parameters.

Signed-off-by: Luigi Mori <l@isidora.org>