### PR TITLE
Charts are using patterns as filling

### DIFF
--- a/src/app/dashboard/dashboard.controller.ts
+++ b/src/app/dashboard/dashboard.controller.ts
@@ -32,7 +32,7 @@ export class DashboardController {
 
     indicatorsOptions: any = {
         chart: {
-            type: 'discreteBarChart',
+            type: 'lineChart',
             margin : {
                 top: 0,
                 right: 0,
@@ -43,18 +43,22 @@ export class DashboardController {
             x: function(d: any) { return d.x; },
             y: function(d: any) { return d.y; },
             useInteractiveGuideline: true,
+            transition: 0,
             showXAxis: false,
-            tooltip: {
-                keyFormatter: function(d: any) { return this.moment.unix(d).fromNow().toUpperCase(); },
-                valueFormatter: function(d: any) { return Math.ceil(d); }
+            interactiveLayer: {
+                tooltip: {
+                    headerFormatter: function(d: any) { return this.moment.unix(d).fromNow().toUpperCase(); },
+                    valueFormatter: function(d: any) { return Math.ceil(d); }
+                }
             },
             showYAxis: false,
-            forceY: [],
+            forceY: [0, 1],
             yAxis: {
                 tickFormat: (d: number, i: any) => { return Math.ceil(d); }
             },
             showLegend: false,
-            color: ['#91B7C7']
+            color: ['#91B7C7'],
+            interpolate: 'monotone'
         }
     };
     arOptions: any = {

--- a/src/app/dashboard/dashboard.scss
+++ b/src/app/dashboard/dashboard.scss
@@ -103,7 +103,7 @@
     background-color: #fff;
     margin-left: 0px !important;
     margin-right: 0px !important;
-    border-top: 2px solid $minemeld-miner !important;    
+    border-top: 2px solid $minemeld-miner !important;
 }
 
 .dashboard-label-miner {
@@ -118,7 +118,7 @@
     background-color: #fff;
     margin-left: 0px !important;
     margin-right: 0px !important;
-    border-top: 2px solid $minemeld-processor !important;    
+    border-top: 2px solid $minemeld-processor !important;
 }
 
 .dashboard-label-processor {
@@ -133,7 +133,7 @@
     background-color: #fff;
     margin-left: 0px !important;
     margin-right: 0px !important;
-    border-top: 2px solid $minemeld-output !important;    
+    border-top: 2px solid $minemeld-output !important;
 }
 
 .dashboard-label-output {
@@ -153,4 +153,16 @@
 .dashboard-chart-column {
     padding-left: 5px;
     padding-right: 5px;
+}
+
+.dashboard-ar-chart .nv-series-0 > .nv-area {
+    fill: url(#pattern-added);
+}
+
+.dashboard-ar-chart .nv-series-1 > .nv-area {
+    fill: url(#pattern-removed);
+}
+
+.dashboard-indicators-chart .nv-series-0 > .nv-area {
+    fill: url(#pattern-indicators);
 }

--- a/src/app/dashboard/view.html
+++ b/src/app/dashboard/view.html
@@ -1,3 +1,18 @@
+<!-- patterns for chart fills -->
+<svg height="6" width="6" xmlns="http://www.w3.org/2000/svg" version="1.1">
+  <defs>
+    <pattern id="pattern-added" patternUnits="userSpaceOnUse" width="3" height="3">
+      <path d='M0 3L3 0M-1 1L1 -1M2 4L4 2' stroke='#586994' stroke-width='1'/>
+    </pattern>
+    <pattern id="pattern-removed" patternUnits="userSpaceOnUse" width="3" height="3">
+      <path d='M0 3L3 0M-1 1L1 -1M2 4L4 2' stroke='#977390' stroke-width='1'/>
+    </pattern>
+    <pattern id="pattern-indicators" patternUnits="userSpaceOnUse" width="3" height="3">
+      <path d='M0 3L3 0M-1 1L1 -1M2 4L4 2' stroke='#91B7C7' stroke-width='1'/>
+    </pattern>
+  </defs>
+</svg>
+
 <!-- nodes -->
 <div class="row dashboard-row">
   <div class="col-sm-3 col-md-3">
@@ -35,7 +50,7 @@
     <div class="row dashboard-row-processor">
       <div class="col-xs-12 dashboard-chart-column">
         <div class="dashboard-chart-title small m-t-xs"># OF INDICATORS (LAST {{dashboard.chartRange}})</div>
-        <nvd3 ng-if="dashboard.minemeldMetrics.length" api="dashboard.minemeldMetricsLengthAPI"
+        <nvd3 class="dashboard-indicators-chart" ng-if="dashboard.minemeldMetrics.length" api="dashboard.minemeldMetricsLengthAPI"
           options="dashboard.indicatorsOptions" data="dashboard.minemeldMetrics.length"></nvd3>
         <div ng-if="!dashboard.minemeldMetrics.length" class="dashboard-chart-placeholder">NO STATS YET</div>
       </div>
@@ -70,7 +85,7 @@
     <div class="row dashboard-row-miner">
       <div class="col-xs-12 dashboard-chart-column">
         <div class="dashboard-chart-title small m-t-xs"># OF INDICATORS (LAST {{dashboard.chartRange}})</div>
-        <nvd3 ng-if="dashboard.minersMetrics.length" options="dashboard.indicatorsOptions"
+        <nvd3 class="dashboard-indicators-chart" ng-if="dashboard.minersMetrics.length" options="dashboard.indicatorsOptions"
           api="dashboard.minersMetricsLengthAPI" data="dashboard.minersMetrics.length"></nvd3>
         <div ng-if="!dashboard.minersMetrics.length" class="dashboard-chart-placeholder">NO STATS YET</div>
       </div>
@@ -80,7 +95,7 @@
     <div class="row dashboard-row-miner">
       <div class="col-xs-12 dashboard-chart-column">
         <div class="dashboard-chart-title small m-t-xs">ADDED/AGED OUT (LAST {{dashboard.chartRange}})</div>
-        <nvd3 ng-if="dashboard.minersMetrics.ar" options="dashboard.arOptions"
+        <nvd3 class="dashboard-ar-chart" ng-if="dashboard.minersMetrics.ar" options="dashboard.arOptions"
           api="dashboard.minersMetricsArAPI" data="dashboard.minersMetrics.ar"></nvd3>
         <div ng-if="!dashboard.minersMetrics.ar" class="dashboard-chart-placeholder">NO STATS YET</div>
       </div>
@@ -115,7 +130,7 @@
     <div class="row dashboard-row-output">
       <div class="col-xs-12 dashboard-chart-column">
         <div class="dashboard-chart-title small m-t-xs"># OF INDICATORS (LAST {{dashboard.chartRange}})</div>
-        <nvd3 ng-if="dashboard.outputsMetrics.length" options="dashboard.indicatorsOptions"
+        <nvd3 class="dashboard-indicators-chart" ng-if="dashboard.outputsMetrics.length" options="dashboard.indicatorsOptions"
           api="dashboard.outputsMetricsLengthAPI" data="dashboard.outputsMetrics.length"></nvd3>
         <div ng-if="!dashboard.outputsMetrics.length" class="dashboard-chart-placeholder">NO STATS YET</div>
       </div>
@@ -125,7 +140,7 @@
     <div class="row dashboard-row-output">
       <div class="col-xs-12 dashboard-chart-column">
         <div class="dashboard-chart-title small m-t-xs">ADDED/REMOVED (LAST {{dashboard.chartRange}})</div>
-        <nvd3 ng-if="dashboard.outputsMetrics.ar" options="dashboard.arOptions"
+        <nvd3 class="dashboard-ar-chart" ng-if="dashboard.outputsMetrics.ar" options="dashboard.arOptions"
           api="dashboard.outputsMetricsArAPI" data="dashboard.outputsMetrics.ar"></nvd3>
         <div ng-if="!dashboard.outputsMetrics.ar" class="dashboard-chart-placeholder">NO STATS YET</div>
       </div>

--- a/src/app/nodedetail/nodedetail.scss
+++ b/src/app/nodedetail/nodedetail.scss
@@ -68,7 +68,7 @@
 
 .nodedetails-stats-table > thead th {
   font-size: 12px;
-  font-weight: 400 !important;  
+  font-weight: 400 !important;
 }
 
 .nodedetails-stats-table > tbody {
@@ -89,7 +89,7 @@
 
 .nodedetail-info-table > thead th {
   font-size: 12px;
-  font-weight: 400 !important;  
+  font-weight: 400 !important;
 }
 
 .nodedetail-info-table > tbody {
@@ -128,13 +128,13 @@
 .nodedetail-info-config > table table {
   margin-top: 0;
   background-color: lighten($body-bg, 2%) !important;
-  font-size: 12px;  
+  font-size: 12px;
 }
 
 .nodedetail-info-config > table table > thead th {
   background-color: darken($body-bg, 5%);
   font-size: 12px;
-  font-weight: 400 !important;  
+  font-weight: 400 !important;
 }
 
 .nodedetail-info-clickable:hover{
@@ -192,6 +192,10 @@
     height: 200px;
     border: 1px solid #ccc;
     border-radius: 4px;
+}
+
+.nodedetail-metric-chart .nv-series-0 > .nv-area {
+    fill: url(#pattern-metric);
 }
 
 .ace-focus {

--- a/src/app/nodedetail/view.stats.html
+++ b/src/app/nodedetail/view.stats.html
@@ -1,3 +1,12 @@
+<!-- patterns for chart fills -->
+<svg height="6" width="6" xmlns="http://www.w3.org/2000/svg" version="1.1">
+  <defs>
+    <pattern id="pattern-metric" patternUnits="userSpaceOnUse" width="3" height="3">
+      <path d='M0 3L3 0M-1 1L1 -1M2 4L4 2' stroke='#ff7f0e' stroke-width='1'/>
+    </pattern>
+  </defs>
+</svg>
+
 <div class="row">
     <div class="col-sm-12 col-md-12">
         <h5 class="m-b-xs">STATISTICS</h5>
@@ -10,7 +19,7 @@
                 <col style="width: 15%">
                 <col style="width: 10%">
                 <col style="width: 75%">
-            </colgroup> 
+            </colgroup>
             <thead>
                 <th>METRIC</th>
                 <th>CURRENT</th>
@@ -22,7 +31,7 @@
                     <td>{{ nodedetailstats.nodeState.length }}</td>
                     <td>
                         <div class="nodedetail-nvd3-container">
-                            <nvd3 api="nodedetailstats.chartApi.indicators" options="nodedetailstats.chartOptions"
+                            <nvd3 class="nodedetail-metric-chart" api="nodedetailstats.chartApi.indicators" options="nodedetailstats.chartOptions"
                                 data="nodedetailstats.metrics.indicators"></nvd3>
                         </div>
                     </td>
@@ -38,7 +47,7 @@
                 <col style="width: 15%">
                 <col style="width: 10%">
                 <col style="width: 75%">
-            </colgroup> 
+            </colgroup>
             <thead>
                 <th>METRIC</th>
                 <th>SINCE<br>ENGINE START</th>
@@ -50,7 +59,7 @@
                     <td>{{ nodedetailstats.nodeState.statistics[name] || 0 }}</td>
                     <td>
                         <div class="nodedetail-nvd3-container">
-                            <nvd3 api="nodedetailstats.chartApi[name]" options="nodedetailstats.chartOptions"
+                            <nvd3 class="nodedetail-metric-chart" api="nodedetailstats.chartApi[name]" options="nodedetailstats.chartOptions"
                                 data="nodedetailstats.metrics[name]"></nvd3>
                         </div>
                     </td>


### PR DESCRIPTION
## Motivation

Because charts are awesome when filled with patterns.

## Modifications

- introduced SVG patterns in the dashboard and nodedetail stats view
- inside SCSS forced the filling of the area of the charts to the SVG patterns
- switched indicators length on the dashboard from bars to line, because it looks better.

## Result

Improved awesomeness.

Signed-off-by: Luigi Mori <l@isidora.org>