### PR TITLE
Added support for sub_state_message

### DIFF
--- a/src/app/nodedetail/autofocusel.info.html
+++ b/src/app/nodedetail/autofocusel.info.html
@@ -47,8 +47,12 @@
                     <td>LAST RUN</td>
                     <td>
                         <span ng-bind="nodedetailinfo.nodeState.last_run | date:'yyyy-MM-dd HH:mm:ss Z'"></span>
-                        <span ng-if="nodedetailinfo.nodeState.sub_state"
-                              ng-class="['label', {WAITING: 'label-default', POLLING:'label-primary', ERROR:'label-danger', SUCCESS:'label-success', REBUILDING:'label-warning'}[nodedetailinfo.nodeState.sub_state]]"
+                        <span ng-if="nodedetailinfo.nodeState.sub_state && nodedetailinfo.nodeState.sub_state !== 'ERROR'"
+                              ng-class="['label', {WAITING: 'label-default', POLLING:'label-primary', SUCCESS:'label-success', REBUILDING:'label-warning'}[nodedetailinfo.nodeState.sub_state]]"
+                              ng-bind="nodedetailinfo.nodeState.sub_state"></span>
+                        <span ng-if="nodedetailinfo.nodeState.sub_state && nodedetailinfo.nodeState.sub_state === 'ERROR'"
+                              ng-class="['label', 'label-danger']"
+                              tooltip="{{ nodedetailinfo.nodeState.sub_state_message }}"
                               ng-bind="nodedetailinfo.nodeState.sub_state"></span>
                         <span tooltip="run now"
                               tooltip-popup-delay="200"

--- a/src/app/nodedetail/cif.info.html
+++ b/src/app/nodedetail/cif.info.html
@@ -62,8 +62,12 @@
                     <td>LAST RUN</td>
                     <td>
                         <span ng-bind="nodedetailinfo.nodeState.last_run | date:'yyyy-MM-dd HH:mm:ss Z'"></span>
-                        <span ng-if="nodedetailinfo.nodeState.sub_state"
-                              ng-class="['label', {WAITING: 'label-default', POLLING:'label-primary', ERROR:'label-danger', SUCCESS:'label-success', REBUILDING:'label-warning'}[nodedetailinfo.nodeState.sub_state]]"
+                        <span ng-if="nodedetailinfo.nodeState.sub_state && nodedetailinfo.nodeState.sub_state !== 'ERROR'"
+                              ng-class="['label', {WAITING: 'label-default', POLLING:'label-primary', SUCCESS:'label-success', REBUILDING:'label-warning'}[nodedetailinfo.nodeState.sub_state]]"
+                              ng-bind="nodedetailinfo.nodeState.sub_state"></span>
+                        <span ng-if="nodedetailinfo.nodeState.sub_state && nodedetailinfo.nodeState.sub_state === 'ERROR'"
+                              ng-class="['label', 'label-danger']"
+                              tooltip="{{ nodedetailinfo.nodeState.sub_state_message }}"
                               ng-bind="nodedetailinfo.nodeState.sub_state"></span>
                         <span tooltip="run now"
                               tooltip-popup-delay="200"

--- a/src/app/nodedetail/credentials.info.html
+++ b/src/app/nodedetail/credentials.info.html
@@ -47,8 +47,12 @@
                     <td>LAST RUN</td>
                     <td>
                         <span ng-bind="nodedetailinfo.nodeState.last_run | date:'yyyy-MM-dd HH:mm:ss Z'"></span>
-                        <span ng-if="nodedetailinfo.nodeState.sub_state"
-                              ng-class="['label', {WAITING: 'label-default', POLLING:'label-primary', ERROR:'label-danger', SUCCESS:'label-success', REBUILDING:'label-warning'}[nodedetailinfo.nodeState.sub_state]]"
+                        <span ng-if="nodedetailinfo.nodeState.sub_state && nodedetailinfo.nodeState.sub_state !== 'ERROR'"
+                              ng-class="['label', {WAITING: 'label-default', POLLING:'label-primary', SUCCESS:'label-success', REBUILDING:'label-warning'}[nodedetailinfo.nodeState.sub_state]]"
+                              ng-bind="nodedetailinfo.nodeState.sub_state"></span>
+                        <span ng-if="nodedetailinfo.nodeState.sub_state && nodedetailinfo.nodeState.sub_state === 'ERROR'"
+                              ng-class="['label', 'label-danger']"
+                              tooltip="{{ nodedetailinfo.nodeState.sub_state_message }}"
                               ng-bind="nodedetailinfo.nodeState.sub_state"></span>
                         <span tooltip="run now"
                               tooltip-popup-delay="200"

--- a/src/app/nodedetail/proofpoint.info.html
+++ b/src/app/nodedetail/proofpoint.info.html
@@ -47,8 +47,12 @@
                     <td>LAST RUN</td>
                     <td>
                         <span ng-bind="nodedetailinfo.nodeState.last_run | date:'yyyy-MM-dd HH:mm:ss Z'"></span>
-                        <span ng-if="nodedetailinfo.nodeState.sub_state"
-                              ng-class="['label', {WAITING: 'label-default', POLLING:'label-primary', ERROR:'label-danger', SUCCESS:'label-success', REBUILDING:'label-warning'}[nodedetailinfo.nodeState.sub_state]]"
+                        <span ng-if="nodedetailinfo.nodeState.sub_state && nodedetailinfo.nodeState.sub_state !== 'ERROR'"
+                              ng-class="['label', {WAITING: 'label-default', POLLING:'label-primary', SUCCESS:'label-success', REBUILDING:'label-warning'}[nodedetailinfo.nodeState.sub_state]]"
+                              ng-bind="nodedetailinfo.nodeState.sub_state"></span>
+                        <span ng-if="nodedetailinfo.nodeState.sub_state && nodedetailinfo.nodeState.sub_state === 'ERROR'"
+                              ng-class="['label', 'label-danger']"
+                              tooltip="{{ nodedetailinfo.nodeState.sub_state_message }}"
                               ng-bind="nodedetailinfo.nodeState.sub_state"></span>
                         <span tooltip="run now"
                               tooltip-popup-delay="200"

--- a/src/app/nodedetail/recordedfuture.info.html
+++ b/src/app/nodedetail/recordedfuture.info.html
@@ -40,8 +40,12 @@
                     <td>LAST RUN</td>
                     <td>
                         <span ng-bind="nodedetailinfo.nodeState.last_run | date:'yyyy-MM-dd HH:mm:ss Z'"></span>
-                        <span ng-if="nodedetailinfo.nodeState.sub_state"
-                              ng-class="['label', {WAITING: 'label-default', POLLING:'label-primary', ERROR:'label-danger', SUCCESS:'label-success', REBUILDING:'label-warning'}[nodedetailinfo.nodeState.sub_state]]"
+                        <span ng-if="nodedetailinfo.nodeState.sub_state && nodedetailinfo.nodeState.sub_state !== 'ERROR'"
+                              ng-class="['label', {WAITING: 'label-default', POLLING:'label-primary', SUCCESS:'label-success', REBUILDING:'label-warning'}[nodedetailinfo.nodeState.sub_state]]"
+                              ng-bind="nodedetailinfo.nodeState.sub_state"></span>
+                        <span ng-if="nodedetailinfo.nodeState.sub_state && nodedetailinfo.nodeState.sub_state === 'ERROR'"
+                              ng-class="['label', 'label-danger']"
+                              tooltip="{{ nodedetailinfo.nodeState.sub_state_message }}"
                               ng-bind="nodedetailinfo.nodeState.sub_state"></span>
                         <span tooltip="run now"
                               tooltip-popup-delay="200"

--- a/src/app/nodedetail/threatqexport.info.html
+++ b/src/app/nodedetail/threatqexport.info.html
@@ -48,8 +48,12 @@
                     <td>LAST RUN</td>
                     <td>
                         <span ng-bind="nodedetailinfo.nodeState.last_run | date:'yyyy-MM-dd HH:mm:ss Z'"></span>
-                        <span ng-if="nodedetailinfo.nodeState.sub_state"
-                              ng-class="['label', {WAITING: 'label-default', POLLING:'label-primary', ERROR:'label-danger', SUCCESS:'label-success', REBUILDING:'label-warning'}[nodedetailinfo.nodeState.sub_state]]"
+                        <span ng-if="nodedetailinfo.nodeState.sub_state && nodedetailinfo.nodeState.sub_state !== 'ERROR'"
+                              ng-class="['label', {WAITING: 'label-default', POLLING:'label-primary', SUCCESS:'label-success', REBUILDING:'label-warning'}[nodedetailinfo.nodeState.sub_state]]"
+                              ng-bind="nodedetailinfo.nodeState.sub_state"></span>
+                        <span ng-if="nodedetailinfo.nodeState.sub_state && nodedetailinfo.nodeState.sub_state === 'ERROR'"
+                              ng-class="['label', 'label-danger']"
+                              tooltip="{{ nodedetailinfo.nodeState.sub_state_message }}"
                               ng-bind="nodedetailinfo.nodeState.sub_state"></span>
                         <span tooltip="run now"
                               tooltip-popup-delay="200"

--- a/src/app/nodedetail/view.info.html
+++ b/src/app/nodedetail/view.info.html
@@ -33,8 +33,12 @@
                     <td>LAST RUN</td>
                     <td>
                         <span ng-bind="nodedetailinfo.nodeState.last_run | date:'yyyy-MM-dd HH:mm:ss Z'"></span>
-                        <span ng-if="nodedetailinfo.nodeState.sub_state"
-                              ng-class="['label', {WAITING: 'label-default', POLLING:'label-primary', ERROR:'label-danger', SUCCESS:'label-success', REBUILDING:'label-warning'}[nodedetailinfo.nodeState.sub_state]]"
+                        <span ng-if="nodedetailinfo.nodeState.sub_state && nodedetailinfo.nodeState.sub_state !== 'ERROR'"
+                              ng-class="['label', {WAITING: 'label-default', POLLING:'label-primary', SUCCESS:'label-success', REBUILDING:'label-warning'}[nodedetailinfo.nodeState.sub_state]]"
+                              ng-bind="nodedetailinfo.nodeState.sub_state"></span>
+                        <span ng-if="nodedetailinfo.nodeState.sub_state && nodedetailinfo.nodeState.sub_state === 'ERROR'"
+                              ng-class="['label', 'label-danger']"
+                              tooltip="{{ nodedetailinfo.nodeState.sub_state_message }}"
                               ng-bind="nodedetailinfo.nodeState.sub_state"></span>
                         <span tooltip="run now"
                               tooltip-popup-delay="200"

--- a/src/app/nodes/nodes.controller.ts
+++ b/src/app/nodes/nodes.controller.ts
@@ -139,7 +139,11 @@ export class NodesController {
                 var result: string = he.encode(data, {strict: true});
 
                 if (full.sub_state && full.sub_state === 'ERROR') {
-                    result = result + ' <span class="text-danger glyphicon glyphicon-exclamation-sign"></span>';
+                    result = result + ' <span';
+                    if (full.sub_state_message) {
+                        result = result + ' tooltip="' + full.sub_state_message +'"';
+                    }
+                    result = result + 'class="text-danger glyphicon glyphicon-exclamation-sign"></span>';
                 }
 
                 return result;


### PR DESCRIPTION
## Motivation

Nodes based on minemeld.ft.basepoller now report a sub_state_message field in their status. This field adds some additional information about the sub_state.
This patch uses this field to add informative tooltips in the UI when an ERROR sub state is reported from basepoller nodes.

## Modifications

In the NODES view and in the node detail INFO view when an ERROR sub state is reported, a tooltip has been added to show the sub state message.

## Result

Informative ERROR tooltips.

Signed-off-by: Luigi Mori <l@isidora.org>