### PR TITLE
Support for additional metadata inside prototype

### DIFF
--- a/src/app/index.scss
+++ b/src/app/index.scss
@@ -108,6 +108,27 @@ $icon-font-path: "../../bower_components/bootstrap-sass/assets/fonts/bootstrap/"
   @include label-variant($minemeld-processor);
 }
 
+.tag-prototype {
+  font-size: 75% !important;
+  font-weight: 600 !important;
+  border-radius: 0 !important;
+  @include label-variant(darken($body-bg, 50%));
+}
+
+.label-indicator-type {
+  @include label-variant($minemeld-system);
+}
+
+.label-container {
+  line-height: 1.7;
+}
+
+.label-container > .label {
+  line-height: 1.5;
+  display: inline-block;
+  vertical-align: 0.2em;
+}
+
 .cursor-pointer {
   cursor: pointer !important;
 }

--- a/src/app/prototypeadd/prototypeadd.controller.ts
+++ b/src/app/prototypeadd/prototypeadd.controller.ts
@@ -13,12 +13,16 @@ export class PrototypeAddController {
     localLibrary: IMinemeldPrototypeLibrary;
     prototype: string;
 
+    availableTags: string[] = [];
+
     name: string;
     class: string;
     description: string;
     nodeType: string;
     developmentStatus: string;
     config: string;
+    indicatorTypes: string[];
+    tags: string[];
 
     saving: boolean = false;
 
@@ -26,6 +30,18 @@ export class PrototypeAddController {
         'miner',
         'processor',
         'output'
+    ];
+
+    availableITypes: string[] = [
+        'md5',
+        'sha256',
+        'sha1',
+        'ssdeep',
+        'URL',
+        'domain',
+        'IPv4',
+        'IPv6',
+        'any'
     ];
 
     availableDevelopmentStatuses: string[] = [
@@ -66,6 +82,10 @@ export class PrototypeAddController {
             this.nodeType = result.nodeType;
             this.developmentStatus = result.developmentStatus;
             this.config = result.config;
+            this.indicatorTypes = result.indicatorTypes;
+            console.log(this.indicatorTypes);
+            this.tags = result.tags;
+            this.availableTags = angular.copy(result.tags);
         }, (error: any) => {
             toastr.error('ERROR RETRIEVING PROTOTYPE ' + this.prototype + ': ' + error.statusText);
         });
@@ -80,6 +100,12 @@ export class PrototypeAddController {
         angular.element('.ace_text-input').on('blur', (event: any) => {
             angular.element(event.currentTarget.parentNode).removeClass('ace-focus');
         });
+    }
+
+    itypesSelected(): void {
+        if (this.indicatorTypes.indexOf('any') !== -1) {
+            this.indicatorTypes = ['any'];
+        }
     }
 
     valid(): boolean {
@@ -137,6 +163,14 @@ export class PrototypeAddController {
 
         if (this.nodeType) {
             optionalParams.nodeType = this.nodeType;
+        }
+
+        if (this.indicatorTypes) {
+            optionalParams.indicatorTypes = this.indicatorTypes;
+        }
+
+        if (this.tags) {
+            optionalParams.tags = this.tags;
         }
 
         this.saving = true;

--- a/src/app/prototypeadd/prototypeadd.controller.ts
+++ b/src/app/prototypeadd/prototypeadd.controller.ts
@@ -83,7 +83,6 @@ export class PrototypeAddController {
             this.developmentStatus = result.developmentStatus;
             this.config = result.config;
             this.indicatorTypes = result.indicatorTypes;
-            console.log(this.indicatorTypes);
             this.tags = result.tags;
             this.availableTags = angular.copy(result.tags);
         }, (error: any) => {

--- a/src/app/prototypeadd/view.html
+++ b/src/app/prototypeadd/view.html
@@ -59,6 +59,33 @@
                 <input ng-disabled="true" type="text" ng-model="vm.class" class="form-control" placeholder="Class (required)" required>
             </div>
         </div>
+        <div class="form-group">
+            <label class="col-sm-2 col-md-2 control-label">INDICATOR TYPES</label>
+            <div class="col-sm-6 col-md-6">
+                <ui-select multiple ng-model="vm.indicatorTypes" theme="bootstrap" on-select="vm.itypesSelected()">
+                    <ui-select-match placeholder="Add indicator type...">{{ $item }}</ui-select-match>
+                    <ui-select-choices repeat="itype as itype in vm.availableITypes | filter: $select.search">
+                        <div>
+                            <span ng-bind-html="itype | highlight: $select.search"></span>
+                        </div>
+                    </ui-select-choices>
+                </ui-select>
+            </div>
+        </div>
+        <div class="form-group">
+            <label class="col-sm-2 col-md-2 control-label">TAGS</label>
+            <div class="col-sm-6 col-md-6">
+                <ui-select multiple ng-model="vm.tags" theme="bootstrap" tagging tagging-label="">
+                    <ui-select-match placeholder="Add tags...">{{ $item }}</ui-select-match>
+                    <ui-select-choices repeat="tag as tag in vm.availableTags | filter: $select.search">
+                        <div>
+                            <span ng-bind-html="tag | highlight: $select.search"></span>
+                        </div>
+                    </ui-select-choices>
+                    <ui-select-no-choice><i>Type to add a new tag</i></ui-select-no-choice>
+                </ui-select>
+            </div>
+        </div>
         <div id="#fgConfig" class="form-group">
             <label class="col-sm-2 col-md-2 control-label">CONFIG</label>
             <div class="col-sm-6 col-md-6">

--- a/src/app/prototypedetail/view.html
+++ b/src/app/prototypedetail/view.html
@@ -59,6 +59,24 @@
         <div>{{ vm.prototype.class }}</div>
     </div>
 </div>
+<div class="row">
+    <div class="col-sm-12 col-md-12 prototypedetail-section">
+        <h4>INDICATOR TYPES</h4>
+        <div>
+            <span ng-if="!vm.prototype.indicator_types"><i>None</i></span>
+            <span ng-if="vm.prototype.indicator_types" ng-repeat="itype in vm.prototype.indicator_types" class="label label-indicator-type m-r-xs">{{ itype }}</span>
+        </div>
+    </div>
+</div>
+<div class="row">
+    <div class="col-sm-12 col-md-12 prototypedetail-section">
+        <h4>TAGS</h4>
+        <div>
+            <span ng-if="vm.prototype.tags" ng-repeat="tag in vm.prototype.tags" class="label tag-prototype m-r-xs">{{ tag }}</span>
+            <span ng-if="!vm.prototype.tags"><i>None</i></span>
+        </div>
+    </div>
+</div>
 <div class="row" ng-if="vm.prototype.config">
     <div class="col-sm-12 col-md-12 prototypedetail-section">
         <h4 class="m-b-xs">CONFIG</h4>

--- a/src/app/prototypes/prototypes.scss
+++ b/src/app/prototypes/prototypes.scss
@@ -25,3 +25,10 @@
 .prototypes-label-unk {
     background-color: $minemeld-system;
 }
+
+.prototypes-name {
+    white-space: nowrap;
+    max-width: 300px;
+    overflow-x: hidden;
+    text-overflow: ellipsis;
+}

--- a/src/app/services/prototype.ts
+++ b/src/app/services/prototype.ts
@@ -13,6 +13,8 @@ export interface IMinemeldPrototypeLibrary {
 export interface IMinemeldPrototypeMetadata {
     description?: string;
     nodeType?: string;
+    indicatorTypes?: string[];
+    tags?: string[];
     developmentStatus?: string;
     author?: string;
 }

--- a/src/app/styles/bootstrap-theme.scss
+++ b/src/app/styles/bootstrap-theme.scss
@@ -73,6 +73,10 @@ div.main-container {
     margin-top: 5px;
 }
 
+.m-r-xs {
+    margin-right: 5px;
+}
+
 .albert_stripe {
     float: left;
     height: 3px;


### PR DESCRIPTION
Now *indicator_types* and *tags* fields are supported by prototype library, prototype detail and prototype add views.