### PR TITLE
Add indicator types check during configuration

### DIFF
--- a/src/app/components/nodeconfig/nodeconfig.directive.ts
+++ b/src/app/components/nodeconfig/nodeconfig.directive.ts
@@ -15,9 +15,14 @@ export function nodeConfig(): ng.IDirective {
 /** @ngInject */
 export class NodeConfigController {
     config: any;
+    num_properties: number;
 
     constructor() {
         ;
+    }
+
+    $onInit() {
+        this.num_properties = Object.keys(this.config).length;
     }
 
     typeOf(o: any) {

--- a/src/app/components/nodeconfig/nodeconfig.html
+++ b/src/app/components/nodeconfig/nodeconfig.html
@@ -1,4 +1,7 @@
-<table class="table table-condensed">
+<div ng-if="vm.num_properties == 0">
+    <i>Default</i>
+</div>
+<table ng-if="vm.num_properties != 0" class="table table-condensed">
     <colgroup>
         <col style="width: 15%">
         <col>

--- a/src/app/config/config.controller.ts
+++ b/src/app/config/config.controller.ts
@@ -435,6 +435,9 @@ export class ConfigController {
                         if (result.node_type) {
                             node.properties.node_type = result.node_type;
                         }
+                        if (result.indicator_types) {
+                            node.properties.indicator_types = result.indicator_types;
+                        }
                     }
 
                     return node;
@@ -506,6 +509,7 @@ export class ConfigureInputsController {
     nodeConfig: IMinemeldConfigNode;
     nodeType: string;
     nodeTypeLimit: number;
+    indicatorTypes: string[];
 
     noChoiceMessage: string;
 
@@ -524,6 +528,9 @@ export class ConfigureInputsController {
         this.nodeConfig = this.MinemeldConfigService.nodesConfig[nodenum];
         if (typeof this.nodeConfig.properties.node_type !== 'undefined') {
             this.nodeType = this.nodeConfig.properties.node_type;
+        }
+        if (typeof this.nodeConfig.properties.indicator_types !== 'undefined') {
+            this.indicatorTypes = this.nodeConfig.properties.indicator_types;
         }
         if (this.nodeType === 'output') {
             this.nodeTypeLimit = 1;
@@ -650,6 +657,28 @@ export class ConfigureInputsController {
 
                 return true;
             });
+        }
+        if (!this.expertMode && this.indicatorTypes) {
+            if (this.indicatorTypes.length !== 0 && this.indicatorTypes[0] !== 'any') {
+                t = t.filter((x: IMinemeldConfigNode) => {
+                    var x_it: string[];
+
+                    if (!x.properties.indicator_types) {
+                        return true;
+                    }
+                    x_it = x.properties.indicator_types;
+
+                    if (x_it.length === 0 || x_it[0] === 'any') {
+                        return true;
+                    }
+                    for (var j: number = 0; j < x_it.length; j++) {
+                        if (this.indicatorTypes.indexOf(x_it[j]) !== -1) {
+                            return true;
+                        }
+                    }
+                    return false;
+                });
+            }
         }
 
         this.availableInputs = t.map((x: IMinemeldConfigNode) => {

--- a/src/app/config/configexport.controller.ts
+++ b/src/app/config/configexport.controller.ts
@@ -58,6 +58,7 @@ export class ConfigureExportController {
             oconfig[currentNode.name] = angular.copy(currentNode.properties);
 
             delete oconfig[currentNode.name]['node_type'];
+            delete oconfig[currentNode.name]['indicator_types'];
 
             if (typeof oconfig[currentNode.name].inputs !== 'undefined' && !(oconfig[currentNode.name].inputs instanceof Array)) {
                 delete oconfig[currentNode.name]['inputs'];

--- a/src/app/prototypedetail/view.html
+++ b/src/app/prototypedetail/view.html
@@ -64,7 +64,7 @@
         <h4>INDICATOR TYPES</h4>
         <div>
             <span ng-if="!vm.prototype.indicator_types"><i>None</i></span>
-            <span ng-if="vm.prototype.indicator_types" ng-repeat="itype in vm.prototype.indicator_types" class="label label-indicator-type m-r-xs">{{ itype }}</span>
+            <span ng-if="vm.prototype.indicator_types || vm.prototype.indicator_types.length == 0" ng-repeat="itype in vm.prototype.indicator_types" class="label label-indicator-type m-r-xs">{{ itype }}</span>
         </div>
     </div>
 </div>
@@ -73,7 +73,7 @@
         <h4>TAGS</h4>
         <div>
             <span ng-if="vm.prototype.tags" ng-repeat="tag in vm.prototype.tags" class="label tag-prototype m-r-xs">{{ tag }}</span>
-            <span ng-if="!vm.prototype.tags"><i>None</i></span>
+            <span ng-if="!vm.prototype.tags || vm.prototype.tags.length == 0"><i>None</i></span>
         </div>
     </div>
 </div>


### PR DESCRIPTION
## Motivation

New prototype metadata has been introduced to list the type of indicators processed by each single prototype. This metadata can be used to guide the user during configuration and avoid typical mistakes like connecting an *IPv4* Miner to a *domain* Aggregator.

## Modifications

- each node in configuration is now decorated with the list of indicator types supported by its prototype. If the prototype has no *indicator_types* metadata an empty list is used and it is treated as *any*
- during INPUTS selection in CONFIG section or while adding a new node, only existing nodes with compatible indicator types are presented. If the selected node has *any* as indicator types all the nodes are presented. Otherwise only nodes able to process at least one of the types of the selected node are presented.

## Result

Improved usability.

Signed-off-by: Luigi Mori <l@isidora.org>