### PR TITLE
Adds support for delete prototype API

### DIFF
--- a/src/app/config/config.controller.ts
+++ b/src/app/config/config.controller.ts
@@ -1,6 +1,6 @@
 /// <reference path="../../../typings/main.d.ts" />
 
-import { IMinemeldConfigService, IMinemeldConfigInfo, IMinemeldConfigNode } from  '../../app/services/config';
+import { IMinemeldConfigService, IMinemeldCandidateConfigInfo, IMinemeldCandidateConfigNode } from  '../../app/services/config';
 import { IConfirmService } from '../../app/services/confirm';
 import { IMinemeldPrototypeService } from '../../app/services/prototype';
 import { IMinemeldSupervisorService } from '../../app/services/supervisor';
@@ -30,8 +30,8 @@ export class ConfigController {
     changed: boolean = false;
     inCommit: boolean = false;
 
-    configInfo: IMinemeldConfigInfo;
-    nodesConfig: IMinemeldConfigNode[];
+    configInfo: IMinemeldCandidateConfigInfo;
+    nodesConfig: IMinemeldCandidateConfigNode[];
 
     /** @ngInject */
     constructor(toastr: any, $scope: angular.IScope, DTOptionsBuilder: any,
@@ -456,7 +456,7 @@ export class ConfigureOutputController {
     MinemeldConfigService: IMinemeldConfigService;
     $modalInstance: angular.ui.bootstrap.IModalServiceInstance;
 
-    nodeConfig: IMinemeldConfigNode;
+    nodeConfig: IMinemeldCandidateConfigNode;
     output: boolean;
     originalOutput: boolean;
 
@@ -506,7 +506,7 @@ export class ConfigureInputsController {
     $modalInstance: angular.ui.bootstrap.IModalServiceInstance;
 
     expertMode: boolean = false;
-    nodeConfig: IMinemeldConfigNode;
+    nodeConfig: IMinemeldCandidateConfigNode;
     nodeType: string;
     nodeTypeLimit: number;
     indicatorTypes: string[];
@@ -576,12 +576,12 @@ export class ConfigureInputsController {
     }
 
     private loadAvailableInputs(): void {
-        var t: IMinemeldConfigNode[];
+        var t: IMinemeldCandidateConfigNode[];
 
         if (!this.expertMode) {
             if (this.inputs.length >= this.nodeTypeLimit) {
                 this.availableInputs = this.inputs.map((i: string) => {
-                    var cn: IMinemeldConfigNode;
+                    var cn: IMinemeldCandidateConfigNode;
                     var nt: string = 'UNKNOWN';
 
                     for (cn of this.MinemeldConfigService.nodesConfig) {
@@ -606,7 +606,7 @@ export class ConfigureInputsController {
         }
 
         t = this.MinemeldConfigService.nodesConfig
-            .filter((x: IMinemeldConfigNode) => {
+            .filter((x: IMinemeldCandidateConfigNode) => {
                 /* first thing remove deleted nodes and itself */
                 if (x.name == this.nodeConfig.name) {
                     return false;
@@ -625,7 +625,7 @@ export class ConfigureInputsController {
             });
 
         if (!this.expertMode && typeof this.nodeType !== 'undefined') {
-            t = t.filter((x: IMinemeldConfigNode) => {
+            t = t.filter((x: IMinemeldCandidateConfigNode) => {
                 var x_nt: string;
 
                 if (typeof x.properties.node_type === 'undefined') {
@@ -660,7 +660,7 @@ export class ConfigureInputsController {
         }
         if (!this.expertMode && this.indicatorTypes) {
             if (this.indicatorTypes.length !== 0 && this.indicatorTypes[0] !== 'any') {
-                t = t.filter((x: IMinemeldConfigNode) => {
+                t = t.filter((x: IMinemeldCandidateConfigNode) => {
                     var x_it: string[];
 
                     if (!x.properties.indicator_types) {
@@ -681,7 +681,7 @@ export class ConfigureInputsController {
             }
         }
 
-        this.availableInputs = t.map((x: IMinemeldConfigNode) => {
+        this.availableInputs = t.map((x: IMinemeldCandidateConfigNode) => {
             var nt: string;
 
             nt = 'UNKNOWN';

--- a/src/app/config/configadd.controller.ts
+++ b/src/app/config/configadd.controller.ts
@@ -1,6 +1,6 @@
 /// <reference path="../../../typings/main.d.ts" />
 
-import { IMinemeldConfigService, IMinemeldConfigNode } from  '../../app/services/config';
+import { IMinemeldConfigService, IMinemeldCandidateConfigNode } from  '../../app/services/config';
 import { IMinemeldPrototypeService } from '../../app/services/prototype';
 
 interface IPrototypesDescription {
@@ -311,18 +311,18 @@ export class ConfigAddController {
     }
 
     private decorateConfigNodes(): angular.IPromise<any> {
-        var t: IMinemeldConfigNode[];
+        var t: IMinemeldCandidateConfigNode[];
         var p: angular.IPromise<any>[] = [];
 
         t = this.MinemeldConfigService.nodesConfig
-            .filter((x: IMinemeldConfigNode) => {
+            .filter((x: IMinemeldCandidateConfigNode) => {
                 if (x.deleted) {
                     return false;
                 }
                 return true;
             });
 
-        angular.forEach(t, (nc: IMinemeldConfigNode) => {
+        angular.forEach(t, (nc: IMinemeldCandidateConfigNode) => {
             if (typeof nc.properties.prototype === 'undefined') {
                 p.push(this.$q((resolve: angular.IQResolveReject<any>) => {
                     resolve({

--- a/src/app/config/configexport.controller.ts
+++ b/src/app/config/configexport.controller.ts
@@ -1,6 +1,6 @@
 /// <reference path="../../../typings/main.d.ts" />
 
-import { IMinemeldConfigService, IMinemeldConfigNode } from  '../../app/services/config';
+import { IMinemeldConfigService, IMinemeldCandidateConfigNode } from  '../../app/services/config';
 
 declare var jsyaml: any;
 
@@ -51,7 +51,7 @@ export class ConfigureExportController {
     private dumpYaml(): void {
         var oconfig: any = {};
 
-        this.MinemeldConfigService.nodesConfig.forEach((currentNode: IMinemeldConfigNode) => {
+        this.MinemeldConfigService.nodesConfig.forEach((currentNode: IMinemeldCandidateConfigNode) => {
             if (currentNode.deleted) {
                 return;
             }

--- a/src/app/config/configimport.controller.ts
+++ b/src/app/config/configimport.controller.ts
@@ -1,6 +1,6 @@
 /// <reference path="../../../typings/main.d.ts" />
 
-import { IMinemeldConfigService, IMinemeldConfigNode } from  '../../app/services/config';
+import { IMinemeldConfigService, IMinemeldCandidateConfigNode } from  '../../app/services/config';
 import { IMinemeldPrototypeService, IMinemeldPrototypeLibrary } from '../../app/services/prototype';
 import { IConfirmService } from '../../app/services/confirm';
 
@@ -301,7 +301,7 @@ export class ConfigureImportController {
         var numRow: number;
         var duplicate: boolean = false;
         var annotations: ConfigAnnotations = new ConfigAnnotations();
-        var node: IMinemeldConfigNode;
+        var node: IMinemeldCandidateConfigNode;
 
         this.progressMax = Object.keys(this.pconfig.nodes).length;
         this.progressValue = 0;
@@ -370,7 +370,7 @@ export class ConfigureImportController {
     }
 
     private deleteAllNodes(): angular.IPromise<any> {
-        return this.MinemeldConfigService.nodesConfig.reduce((prevPromise: angular.IPromise<any>, currentNode: IMinemeldConfigNode, currentIndex: number) => {
+        return this.MinemeldConfigService.nodesConfig.reduce((prevPromise: angular.IPromise<any>, currentNode: IMinemeldCandidateConfigNode, currentIndex: number) => {
             this.progressValue += 1;
 
             if (currentNode.deleted) {

--- a/src/app/config/configureimport.modal.html
+++ b/src/app/config/configureimport.modal.html
@@ -1,5 +1,5 @@
 <div class="modal-header">
-    <h1 class="modal-title">IMPORT CONFIGURATION</h1>
+    <h1 class="modal-title">IMPORT CANDIDATE CONFIGURATION</h1>
 </div>
 <div class="modal-body">
     <div ng-class="['row', {'has-error': !vm.syntaxValid }]">

--- a/src/app/prototypedetail/prototypedetail.controller.ts
+++ b/src/app/prototypedetail/prototypedetail.controller.ts
@@ -1,10 +1,14 @@
 /// <reference path="../../../typings/main.d.ts" />
 
 import { IMinemeldPrototypeService, IMinemeldPrototypeLibrary, IMinemeldPrototype } from '../../app/services/prototype';
+import { IConfirmService } from '../../app/services/confirm';
 
 export class PrototypedetailController {
     MinemeldPrototypeService: IMinemeldPrototypeService;
+    $rootScope: any;
     $state: angular.ui.IStateService;
+    toastr: any;
+    ConfirmService: IConfirmService;
 
     prototypeName: string;
     libraryName: string;
@@ -14,9 +18,14 @@ export class PrototypedetailController {
     /* @ngInject */
     constructor(MinemeldPrototypeService: IMinemeldPrototypeService,
                 $stateParams: angular.ui.IStateParamsService,
+                $rootScope: angular.IRootScopeService,
                 $state: angular.ui.IStateService,
+                ConfirmService: IConfirmService,
                 toastr: any) {
         this.$state = $state;
+        this.$rootScope = $rootScope;
+        this.toastr = toastr;
+        this.ConfirmService = ConfirmService;
 
         this.MinemeldPrototypeService = MinemeldPrototypeService;
 
@@ -29,6 +38,25 @@ export class PrototypedetailController {
             this.prototype = this.library.prototypes[$stateParams['prototypeName']];
         }, (error: any) => {
             toastr.error('ERROR RETRIEVING PROTOTYPES: ' + error.statusText);
+        });
+    }
+
+    public delete() {
+        this.ConfirmService.show(
+            'DELETE PROTOTYPE',
+            'Are you sure you want to delete prototype ' + this.libraryName + '.' + this.prototypeName + ' ?'
+        ).then((result: any) => {
+            this.MinemeldPrototypeService.deletePrototype(this.libraryName + '.' + this.prototypeName).then((result: any) => {
+                this.toastr.success(this.libraryName + '.' + this.prototypeName + ' DELETED');
+                this.MinemeldPrototypeService.invalidateCache();
+                this.$rootScope.mmBack('prototypes');
+            }, (error: any) => {
+                if (error.status === 400) {
+                    this.toastr.error('ERROR DELETING ' + this.libraryName + '.' + this.prototypeName + ': ' + error.data.error.message);
+                } else {
+                    this.toastr.error('ERROR DELETING ' + this.libraryName + '.' + this.prototypeName + ': ' + error.statusText);
+                }
+            });
         });
     }
 }

--- a/src/app/prototypedetail/view.html
+++ b/src/app/prototypedetail/view.html
@@ -2,10 +2,13 @@
     <div class="col-sm-12 col-md-12">
         <h3 class="m-t-xs prototypedetail-title">
             {{ vm.libraryName }}.{{ vm.prototypeName }} <span class="prototypedetail-description">PROTOTYPE</span>
+            <button ng-if="vm.libraryName == 'minemeldlocal'" tooltip-popup-delay="500" tooltip="delete this prototype" type="button" class="config-action btn btn-config-action btn-sm" ng-click="vm.delete()">
+                <span class="glyphicon glyphicon-remove"></span> REMOVE
+            </button>
             <button tooltip-popup-delay="500" tooltip="new prototype from this" type="button" class="config-action btn btn-config-action btn-sm" ng-click="vm.$state.go('prototypeadd', {prototype: vm.libraryName+'.'+vm.prototypeName})">
                 <span class="glyphicon glyphicon-paste"></span> NEW
             </button>
-            <button tooltip-popup-delay="500" tooltip="create a new node from this prototype" type="button" class="config-action btn btn-config-action btn-sm" ng-click="vm.$state.go('configadd', {prototype: vm.libraryName+'.'+vm.prototypeName})">
+            <button tooltip-popup-delay="500" tooltip="new node from this prototype" type="button" class="config-action btn btn-config-action btn-sm" ng-click="vm.$state.go('configadd', {prototype: vm.libraryName+'.'+vm.prototypeName})">
                 <span class="glyphicon glyphicon-duplicate"></span> CLONE
             </button>
         </h3>

--- a/src/app/services/prototype.ts
+++ b/src/app/services/prototype.ts
@@ -35,6 +35,7 @@ export interface IMinemeldPrototypeService {
     getPrototypeYaml(prototypename: string): angular.IPromise<any>;
     setPrototypeYaml(prototypename: string, pclass: string, config: string,
                      optionalParams?: IMinemeldPrototypeMetadata): angular.IPromise<any>;
+    deletePrototype(prototypename: string): angular.IPromise<any>;
     invalidateCache(): void;
 }
 
@@ -171,6 +172,26 @@ export class MinemeldPrototypeService implements IMinemeldPrototypeService {
         prototype.config = config;
 
         return prototypeYaml.post({}, JSON.stringify(prototype)).$promise.then((result: any) => {
+            if ('result' in result) {
+                return result.result;
+            }
+
+            return {};
+        });
+    }
+
+    public deletePrototype(prototypename: string): angular.IPromise<any> {
+        var apiResource: any;
+
+        apiResource = this.MineMeldAPIService.getAPIResource('/prototype/:prototypename', {
+            prototypename: prototypename
+        }, {
+            delete: {
+                method: 'DELETE'
+            }
+        }, false);
+
+        return apiResource.delete({}).$promise.then((result: any) => {
             if ('result' in result) {
                 return result.result;
             }


### PR DESCRIPTION
A new REMOVE icon has been added in the prototype view of local prototype to permit removal of the prototype itself. This is based on the new delete prototype API introduced in minemeld-core.

Signed-off-by: Luigi Mori <l@isidora.org>