### PR TITLE
Engine status

### DIFF
--- a/src/app/components/navbar/navbar.directive.ts
+++ b/src/app/components/navbar/navbar.directive.ts
@@ -1,6 +1,7 @@
 /// <reference path="../../../../typings/main.d.ts" />
 
 import { IMineMeldAPIService } from '../../services/minemeldapi';
+import { IMineMeldEngineStatusService, IMineMeldEngineStatus } from '../../services/enginestatus';
 
 /** @ngInject */
 export function appNavbar(): ng.IDirective {
@@ -21,21 +22,97 @@ export function appNavbar(): ng.IDirective {
 /** @ngInject */
 export class NavbarController {
   MineMeldAPIService: IMineMeldAPIService;
+  MineMeldEngineStatusService: IMineMeldEngineStatusService;
   $state: angular.ui.IStateService;
-  $cookies: angular.cookies.ICookiesService;
+  $timeout: angular.ITimeoutService;
+  $rootScope: angular.IRootScopeService;
+  toastr: any;
+
+  engineStatusChangeSubscription: () => void;
+  lastToast: any;
+
+  engineStatename: string;
+  engineStateIcon: string;
+
+  ICON_MAP: any = {
+    'RUNNING': 'running',
+    'STARTING': 'starting',
+    'STOPPING': 'stopping'
+  };
 
   constructor(MineMeldAPIService: IMineMeldAPIService,
-              $state: angular.ui.IStateService,
-              $cookies: angular.cookies.ICookiesService) {
+              MineMeldEngineStatusService: IMineMeldEngineStatusService,
+              $timeout: angular.ITimeoutService,
+              $rootScope: angular.IRootScopeService,
+              toastr: any,
+              $state: angular.ui.IStateService) {
     this.MineMeldAPIService = MineMeldAPIService;
+    this.MineMeldEngineStatusService = MineMeldEngineStatusService;
+    this.$rootScope = $rootScope;
     this.$state = $state;
-    this.$cookies = $cookies;
+    this.$timeout = $timeout;
+    this.toastr = toastr;
+
+    this.updateEngineStatus();
   }
 
   logout() {
     this.MineMeldAPIService.logOut().finally(() => {
-      this.$cookies.remove('mm-session');
       this.$state.go('login');
     });
+  }
+
+  private updateEngineStatus() {
+    this.MineMeldEngineStatusService.getStatus().then((result: IMineMeldEngineStatus) => {
+      if (result.statename != this.engineStatename) {
+        this.$timeout(() => {
+          var firstStatus: boolean;
+
+          firstStatus = (typeof this.engineStatename === 'undefined');
+          this.engineStatename = result.statename;
+
+          this.updateEngineStateIcon();
+
+          if (!firstStatus || (this.engineStatename !== 'RUNNING')) {
+            this.showNotification();
+          }
+        });
+      }
+
+      if (!this.engineStatusChangeSubscription) {
+        this.engineStatusChangeSubscription = this.$rootScope.$on(
+          'mm-engine-status-changed',
+          this.updateEngineStatus.bind(this)
+        );
+      }
+    });
+  }
+
+  private updateEngineStateIcon(): void {
+    // we do this here because I can't find a good way to express
+    // this logic inside the template
+    if (this.ICON_MAP.hasOwnProperty(this.engineStatename)) {
+      this.engineStateIcon = this.ICON_MAP[this.engineStatename];
+      return;
+    }
+
+    this.engineStateIcon = 'stopped';
+  }
+
+  private showNotification(): void {
+    if (this.lastToast && this.lastToast.isOpened) {
+      this.lastToast.scope.close(true);
+      this.lastToast = undefined;
+    }
+
+    if (this.engineStatename === 'RUNNING' || this.engineStatename === 'STARTING') {
+      this.lastToast = this.toastr.success('ENGINE IS ' + this.engineStatename);
+      return;
+    }
+    if (this.engineStatename === 'STOPPING') {
+      this.lastToast = this.toastr.warning('ENGINE IS ' + this.engineStatename);
+      return;
+    }
+    this.lastToast = this.toastr.error('ENGINE IS ' + this.engineStatename);
   }
 }

--- a/src/app/components/navbar/navbar.html
+++ b/src/app/components/navbar/navbar.html
@@ -24,7 +24,12 @@
           <a ui-sref="admin.users"><span class="glyphicon glyphicon-user"></span> ADMIN</a>
         </li>
         <li>
-          <a ui-sref="system"><span class="glyphicon glyphicon-hdd"></span> SYSTEM</a>
+          <a ui-sref="system">
+            <span tooltip-popup-delay="100" tooltip="engine is {{ vm.engineStatename|lowercase }}" tooltip-placement="bottom">
+              <span class="glyphicon navbar-system-icon-{{ vm.engineStateIcon }}"></span> SYSTEM
+              <div ng-if="vm.engineStateIcon == 'stopped'" class="pull-right navbar-system-badge-stopped"></div>
+            </span>
+          </a>
         </li>
         <li>
           <a title="logout" href="#" ng-click="vm.logout()"><span class="glyphicon glyphicon-log-out"></span></a>

--- a/src/app/components/navbar/navbar.scss
+++ b/src/app/components/navbar/navbar.scss
@@ -1,0 +1,54 @@
+.navbar-system-icon-running {
+    @extend .glyphicon-hdd;
+}
+
+.navbar-system-icon-starting {
+    @extend .glyphicon-hdd;
+    -webkit-animation: navbar-fade 1000ms infinite linear;
+    animation: navbar-fade 1000ms infinite linear;
+}
+
+.navbar-system-icon-stopping {
+    @extend .glyphicon-remove;
+    -webkit-animation: navbar-fade 1000ms infinite linear;
+    animation: navbar-fade 1000ms infinite linear;
+}
+
+.navbar-system-icon-stopped {
+    @extend .glyphicon-remove;
+}
+
+.navbar-system-badge-stopped {
+    display: inline-block;
+    position: relative;
+    left: -($font-size-base/10)*4;
+    height: ($font-size-base/10)*7;
+    width: ($font-size-base/10)*7;
+    border-radius: 50%;
+    background-color: $brand-danger;
+    -webkit-animation: navbar-fade 1000ms infinite linear;
+    animation: navbar-fade 1000ms infinite linear;
+}
+
+@-webkit-keyframes navbar-fade {
+    0% {
+        opacity: 0;
+    }
+    50% {
+        opacity: 1;
+    }
+    100% {
+        opacity: 0;
+    }
+}
+@keyframes navbar-fade {
+    0% {
+        opacity: 0;
+    }
+    50% {
+        opacity: 1;
+    }
+    100% {
+        opacity: 0;
+    }
+}

--- a/src/app/index.module.ts
+++ b/src/app/index.module.ts
@@ -23,7 +23,6 @@ import { AdminUsersController } from './admin/admin.users.controller';
 import { AdminFUsersController } from './admin/admin.fusers.controller';
 import { IndicatorAddController } from './indicatoradd/indicatoradd.controller';
 import { LogsController } from './logs/logs.controller';
-import { appNavbar } from '../app/components/navbar/navbar.directive';
 import { LoginController } from './login/login.controller';
 import { MineMeldAPIService } from './services/minemeldapi';
 import { MinemeldStatusService } from './services/status';
@@ -38,7 +37,9 @@ import { MinemeldEventsService } from './services/events';
 import { MinemeldTracedService } from './services/traced';
 import { ThrottleService } from './services/throttle';
 import { MinemeldAAAService } from './services/aaa';
+import { MineMeldEngineStatusService } from './services/enginestatus';
 import { megaNumber } from './filters/megaNumber';
+import { appNavbar } from '../app/components/navbar/navbar.directive';
 import { minemeldOptions } from '../app/components/options/options.directive';
 import { nodeConfig } from '../app/components/nodeconfig/nodeconfig.directive';
 import { prototypeTooltip } from'../app/components/prototypetooltip/prototypetooltip.directive';
@@ -108,6 +109,7 @@ module minemeldWebui {
   .service('MinemeldTracedService', MinemeldTracedService)
   .service('MinemeldAAAService', MinemeldAAAService)
   .service('ThrottleService', ThrottleService)
+  .service('MineMeldEngineStatusService', MineMeldEngineStatusService)
   .filter('megaNumber', megaNumber)
   .run(minemeldInit)
   ;

--- a/src/app/services/enginestatus.ts
+++ b/src/app/services/enginestatus.ts
@@ -1,0 +1,127 @@
+/// <reference path="../../../typings/main.d.ts" />
+
+import { IMineMeldAPIService } from './minemeldapi';
+import { IMinemeldEventsService } from './events';
+import { IMinemeldSupervisorService } from './supervisor';
+
+export interface IMineMeldEngineStatusService {
+    getStatus(): angular.IPromise<IMineMeldEngineStatus>;
+}
+
+export interface IMineMeldEngineStatus {
+    statename: string;
+}
+
+export class MineMeldEngineStatusService implements IMineMeldEngineStatusService {
+    MineMeldAPIService: IMineMeldAPIService;
+    MinemeldEventsService: IMinemeldEventsService;
+    toastr: any;
+    $interval: angular.IIntervalService;
+    $rootScope: angular.IRootScopeService;
+    $q: angular.IQService;
+    MinemeldSupervisorService: IMinemeldSupervisorService;
+
+    currentStatusDeferred: ng.IDeferred<IMineMeldEngineStatus>;
+    statusSubscription: () => void;
+    currentStatus: IMineMeldEngineStatus;
+    statusUpdatePromise: ng.IPromise<any>;
+
+    /** @ngInject */
+    constructor(MinemeldSupervisorService: IMinemeldSupervisorService,
+                MineMeldAPIService: IMineMeldAPIService,
+                MinemeldEventsService: IMinemeldEventsService,
+                toastr: any,
+                $interval: angular.IIntervalService,
+                $rootScope: angular.IRootScopeService,
+                $q: angular.IQService) {
+        this.MineMeldAPIService = MineMeldAPIService;
+        this.MinemeldEventsService = MinemeldEventsService;
+        this.MinemeldSupervisorService = MinemeldSupervisorService;
+        this.toastr = toastr;
+        this.$interval = $interval;
+        this.$rootScope = $rootScope;
+        this.$q = $q;
+
+        this.currentStatusDeferred = this.$q.defer<IMineMeldEngineStatus>();
+        this.MineMeldAPIService.onLogin(this.initStatusMonitor.bind(this));
+        this.MineMeldAPIService.onLogout(this.destroyStatusMonitor.bind(this));
+        if (this.MineMeldAPIService.isLoggedIn()) {
+            this.initStatusMonitor();
+        }
+    }
+
+    public getStatus(): angular.IPromise<IMineMeldEngineStatus> {
+        if (!this.currentStatus) {
+            /* wait, we don't have the status yet */
+            return this.currentStatusDeferred.promise;
+        }
+
+        return this.$q.when(this.currentStatus);
+    }
+
+    private initStatusMonitor(): void {
+        if (this.statusSubscription) {
+            return;
+        }
+
+        this.updateEngineStatus();
+    }
+
+    private destroyStatusMonitor(): void {
+        if (this.statusSubscription) {
+            this.statusSubscription();
+            this.statusSubscription = undefined;
+        }
+        if (this.statusUpdatePromise) {
+            this.$interval.cancel(this.statusUpdatePromise);
+        }
+
+        this.currentStatus = undefined;
+    }
+
+    private changeListener(event: any, status: string): void {
+        var broadcast: boolean;
+
+        broadcast = this.currentStatus.statename != status;
+        this.currentStatus.statename = status;
+        if (broadcast) {
+            this.$rootScope.$broadcast('mm-engine-status-changed');
+        }
+    }
+
+    private updateEngineStatus(): void {
+        this.MinemeldSupervisorService.getStatus(false).then((result: any) => {
+            var oldStatename: string;
+
+            if (this.currentStatus) {
+                oldStatename = this.currentStatus.statename;
+            }
+
+            this.currentStatus = result.processes['minemeld-engine'];
+
+            if (!this.statusSubscription) {
+                // first update
+                this.statusSubscription = this.$rootScope.$on(
+                    'mm-inner-engine-status-changed',
+                    this.changeListener.bind(this)
+                );
+                this.currentStatusDeferred.resolve(this.currentStatus);
+            }
+
+            if (oldStatename != this.currentStatus.statename) {
+                this.$rootScope.$broadcast('mm-engine-status-changed');
+            }
+        }, (error: any) => {
+            console.log('ERROR RETRIEVING MINEMELD ENGINE STATUS: ' + error.statusText);
+
+            throw error;
+        })
+        .finally(() => {
+            this.statusUpdatePromise = this.$interval(
+                this.updateEngineStatus.bind(this),
+                1 * 60 * 1000, /* do a full refresh every 1 minute */
+                1
+            );
+        });
+    }
+}

--- a/src/app/services/minemeldapi.ts
+++ b/src/app/services/minemeldapi.ts
@@ -149,15 +149,15 @@ export class MineMeldAPIService implements IMineMeldAPIService {
     public logOut(): angular.IPromise<any> {
         var logoutResource: IMineMeldAPIResourceLogOut;
 
-        this.setLoggedIn(false);
-
         logoutResource = <IMineMeldAPIResourceLogOut>this.$resource('/logout', {}, {
             get: {
                 method: 'GET'
             }
         });
 
-        return logoutResource.get().$promise;
+        return logoutResource.get().$promise.finally(() => {
+            this.setLoggedIn(false);
+        });
     }
 
     public isLoggedIn(): boolean {
@@ -192,6 +192,7 @@ export class MineMeldAPIService implements IMineMeldAPIService {
             this.$rootScope.$emit('mm-login');
         } else {
             this.$cookies.remove('mm-ec-login');
+            this.$cookies.remove('mm-session');
             this.$rootScope.$emit('mm-logout');
         }
     }

--- a/src/app/services/status.ts
+++ b/src/app/services/status.ts
@@ -210,7 +210,8 @@ export class MinemeldStatusService implements IMinemeldStatusService {
             return;
         }
 
-        if (e.source[0] === '<') {
+        if (e.source === '<minemeld-engine>') {
+            this.$rootScope.$broadcast('mm-inner-engine-status-changed', e.status);
             return;
         }
 

--- a/src/app/services/supervisor.ts
+++ b/src/app/services/supervisor.ts
@@ -3,7 +3,7 @@
 import { IMineMeldAPIService } from './minemeldapi';
 
 export interface IMinemeldSupervisorService {
-    getStatus(): angular.IPromise<any>;
+    getStatus(cancellable?: boolean): angular.IPromise<any>;
     startEngine(): angular.IPromise<any>;
     stopEngine(): angular.IPromise<any>;
     restartEngine(): angular.IPromise<any>;
@@ -20,14 +20,18 @@ export class MinemeldSupervisorService implements IMinemeldSupervisorService {
         this.MineMeldAPIService = MineMeldAPIService;
     }
 
-    public getStatus(): angular.IPromise<any> {
+    public getStatus(cancellable?: boolean): angular.IPromise<any> {
         var system: angular.resource.IResourceClass<angular.resource.IResource<any>>;
+
+        if (typeof cancellable === 'undefined') {
+            cancellable = true;
+        }
 
         system = this.MineMeldAPIService.getAPIResource('/supervisor', {}, {
             get: {
                 method: 'GET'
             }
-        });
+        }, cancellable);
 
         return system.get().$promise.then((result: any) => {
             if ('result' in result) {


### PR DESCRIPTION
New engine status is introduced to monitor status of engine on the backend. This is then used to notify user of what is happening to the engine and to block commits when the engine is starting or stopping.