### PR TITLE
Adds explicit no cache headers to avoid caching

### DIFF
--- a/src/app/services/minemeldapi.ts
+++ b/src/app/services/minemeldapi.ts
@@ -66,6 +66,18 @@ export class MineMeldAPIService implements IMineMeldAPIService {
         angular.forEach(actions, (action: angular.resource.IActionDescriptor, actionName: string) => {
             action.cancellable = true;
             action.timeout = 45000;
+
+            if (typeof action.headers === 'undefined') {
+                action.headers = {};
+            }
+            action.headers['If-Modified-Since'] = 'Mon, 26 Jul 1997 05:00:00 GMT';
+            action.headers['Cache-Control'] = 'no-cache';
+            action.headers['Pragma'] = 'no-cache';
+
+            if (typeof action.params === 'undefined') {
+                action.params = {};
+            }
+            action.params['_'] = (): string => { return ''+Math.floor(Date.now() / 1000); };
         });
 
         result = <IMineMeldAPIResource>this.$resource(url, paramDefaults, actions);


### PR DESCRIPTION
Adds no cache headers and fake timestamp parameter to MineMeld API calls to dodge caching layers in browser or in middle boxes.

Signed-off-by: Luigi Mori <l@isidora.org>