### PR TITLE
Update .bowerrc to include "registry" configuration variable

### DIFF
--- a/.bowerrc
+++ b/.bowerrc
@@ -1,4 +1,5 @@
 {
+  "registry": "https://registry.bower.io",
   "directory": "bower_components",
   "resolvers": [
     "bower-shrinkwrap-resolver"


### PR DESCRIPTION
The current install will fail as per the issue raised on minemeld-ansible here: https://github.com/PaloAltoNetworks/minemeld-ansible/issues/39. I have tested adding the "registry" configuration variable to .bowerrc locally and this resolves the bower install issue.