### PR TITLE
upgraded to bower 1.8.4 for #117

### DIFF
--- a/bower-shrinkwrap.json
+++ b/bower-shrinkwrap.json
@@ -55,7 +55,8 @@
   },
   "https://github.com/angular/bower-angular.git": {
     "1.5.11": "0f57428c3ffe2f486264ab7fbee3968dccc7b720",
-    "1.5.8": "1.5.8"
+    "1.5.8": "1.5.8",
+    "1.6.4": "097304875bf47c499c7a45711e28f16937dfacfd"
   },
   "https://github.com/chieffancypants/angular-loading-bar.git": {
     "0.8.0": "0.8.0"
@@ -79,7 +80,7 @@
     "0.5.0": "0.5.0"
   },
   "https://github.com/mbostock-bower/d3-bower.git": {
-    "3.5.17": "abe0262a205c9f3755c3a757de4dfd1d49f34b24",
+    "3.5.17": "3.5.17",
     "3.5.5": "3.5.5"
   },
   "https://github.com/moment/moment.git": {

--- a/bower.json
+++ b/bower.json
@@ -15,7 +15,7 @@
     "angular-toastr": "~1.5.0",
     "moment": "~2.10.6",
     "animate.css": "~3.4.0",
-    "angular": "~1.5.6",
+    "angular": "~1.5.11",
     "angular-nvd3": "~1.0.5",
     "angular-datatables": "~0.5.1",
     "angular-loading-bar": "~0.8.0",
@@ -66,6 +66,6 @@
   },
   "resolutions": {
     "jquery": "~2.1.4",
-    "angular": "~1.4.2"
+    "angular": "1.5.11"
   }
 }

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
   },
   "devDependencies": {
     "awesome-typescript-loader": "0.14.2",
-    "bower": "1.7.10",
+    "bower": "1.8.4",
     "bower-shrinkwrap-resolver": "0.4.1",
     "browser-sync": "2.9.12",
     "browser-sync-spa": "1.0.3",


### PR DESCRIPTION
Workaround for #117. Using 1.8.4 as it looks more official, v1.7.10 is not tagged on github.
 
Signed-off-by: Luigi Mori <l@isidora.org>